### PR TITLE
feat (jkube-kit) : Initial draft for JKube Actions Summary (#1033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.12-SNAPSHOT
+* Fix #1033: Print summary after jkube actions
 * Fix #1273: Deprecate `jkube.io` annotation prefix in favor of `jkube.eclipse.org` for JKubeAnnotations
 
 ### 1.11.0 (2023-02-16)

--- a/gradle-plugin/doc/src/main/asciidoc/index.adoc
+++ b/gradle-plugin/doc/src/main/asciidoc/index.adoc
@@ -47,4 +47,5 @@ include::{kitdoc-path}/inc/plugins/_jkube_plugins.adoc[]
 
 include::inc/_kind-filename-type-mapping.adoc[]
 
+include::{kitdoc-path}/inc/_summary.adoc[]
 

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/AutoTLSIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/AutoTLSIT.java
@@ -39,6 +39,13 @@ class AutoTLSIT {
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
         .contains("Using first mentioned service port")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/autotls-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/autotls-route.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/autotls-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ConfigMapIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ConfigMapIT.java
@@ -43,7 +43,17 @@ class ConfigMapIT {
         .contains("jkube-healthcheck-spring-boot: Adding readiness probe on port 8080")
         .contains("jkube-healthcheck-spring-boot: Adding liveness probe on port 8080")
         .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generators applied: [spring-boot]")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/configmap-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/configmap-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/jkube-annotation-directory-configmap.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/jkube-annotation-file-configmap.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/jkube-gradle-sample-config-map-configmap.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -63,6 +73,17 @@ class ConfigMapIT {
         .contains("jkube-healthcheck-spring-boot: Adding readiness probe on port 8080")
         .contains("jkube-healthcheck-spring-boot: Adding liveness probe on port 8080")
         .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generators applied: [spring-boot]")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/configmap-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/configmap-route.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/jkube-annotation-directory-configmap.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/jkube-annotation-file-configmap.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/jkube-gradle-sample-config-map-configmap.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/configmap-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DebugModeIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DebugModeIT.java
@@ -40,7 +40,12 @@ class DebugModeIT {
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
         .contains("Enabling debug on")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/debug-mode-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -55,6 +60,11 @@ class DebugModeIT {
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
         .contains("Enabling debug on")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/debug-mode-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DefaultControllerIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DefaultControllerIT.java
@@ -40,7 +40,12 @@ class DefaultControllerIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/controller-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -56,6 +61,11 @@ class DefaultControllerIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/controller-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DefaultMetadataIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DefaultMetadataIT.java
@@ -39,7 +39,14 @@ class DefaultMetadataIT {
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
         .contains("Using first mentioned service port")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/metadata-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/metadata-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/test-serviceaccount-serviceaccount.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -56,7 +63,15 @@ class DefaultMetadataIT {
         .contains("Adding a default ReplicaSet")
         .contains("Adding revision history limit to 2")
         .contains("Using first mentioned service port")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/metadata-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/metadata-replicaset.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/metadata-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/test-serviceaccount-serviceaccount.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -71,6 +86,14 @@ class DefaultMetadataIT {
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
         .contains("Using first mentioned service port")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/metadata-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/metadata-route.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/metadata-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/test-serviceaccount-serviceaccount.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DependencyResourcesIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DependencyResourcesIT.java
@@ -42,7 +42,13 @@ class DependencyResourcesIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/example-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/web-replicaset.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -59,6 +65,12 @@ class DependencyResourcesIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/example-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/web-replicaset.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DockerfileSimpleIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DockerfileSimpleIT.java
@@ -40,7 +40,13 @@ class DockerfileSimpleIT {
       .contains("Adding a default Deployment")
       .contains("Adding revision history limit to 2")
       .contains("Using first mentioned service port")
-      .contains("validating");
+      .contains("validating")
+      .contains("SUMMARY")
+      .contains("Generated resources:")
+      .contains("build/classes/java/main/META-INF/jkube/kubernetes/dockerfile-simple-deployment.yml")
+      .contains("build/classes/java/main/META-INF/jkube/kubernetes/dockerfile-simple-service.yml")
+      .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+      .contains("SUCCESS");
   }
 
   @Test
@@ -56,6 +62,13 @@ class DockerfileSimpleIT {
       .contains("Converting Deployment to DeploymentConfig")
       .contains("Adding revision history limit to 2")
       .contains("Using first mentioned service port")
-      .contains("validating");
+      .contains("validating")
+      .contains("SUMMARY")
+      .contains("Generated resources:")
+      .contains("build/classes/java/main/META-INF/jkube/openshift/dockerfile-simple-deploymentconfig.yml")
+      .contains("build/classes/java/main/META-INF/jkube/openshift/dockerfile-simple-route.yml")
+      .contains("build/classes/java/main/META-INF/jkube/openshift/dockerfile-simple-service.yml")
+      .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+      .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/FileSecretIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/FileSecretIT.java
@@ -37,7 +37,12 @@ class FileSecretIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/secret-file-secret.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -50,6 +55,11 @@ class FileSecretIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/secret-file-secret.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/GitAnnotationsIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/GitAnnotationsIT.java
@@ -38,7 +38,12 @@ class GitAnnotationsIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/git-annotations-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -52,6 +57,11 @@ class GitAnnotationsIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/git-annotations-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/GroovyDSLImageIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/GroovyDSLImageIT.java
@@ -39,6 +39,12 @@ class GroovyDSLImageIT {
       .contains("Adding a default Deployment")
       .contains("Adding revision history limit to 2")
       .contains("Using first mentioned service port")
-      .contains("validating");
+      .contains("validating")
+      .contains("SUMMARY")
+      .contains("Generated resources:")
+      .contains("build/classes/java/main/META-INF/jkube/kubernetes/groovy-dsl-image-deployment.yml")
+      .contains("build/classes/java/main/META-INF/jkube/kubernetes/groovy-dsl-image-service.yml")
+      .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+      .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ImageChangeTriggerIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ImageChangeTriggerIT.java
@@ -48,6 +48,11 @@ class ImageChangeTriggerIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/imagechangetrigger-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ImagePullPolicyIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ImagePullPolicyIT.java
@@ -62,7 +62,12 @@ class ImagePullPolicyIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/imagepullpolicy-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @ParameterizedTest(name = "resource task with {1} ")
@@ -81,6 +86,11 @@ class ImagePullPolicyIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/imagepullpolicy-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/IngressIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/IngressIT.java
@@ -60,6 +60,13 @@ class IngressIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/ingress-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/ingress-ingress.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/ingress-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/JavaOptionsEnvMergeIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/JavaOptionsEnvMergeIT.java
@@ -38,7 +38,12 @@ class JavaOptionsEnvMergeIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/java-options-env-merge-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -52,6 +57,11 @@ class JavaOptionsEnvMergeIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/java-options-env-merge-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/NameIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/NameIT.java
@@ -52,7 +52,11 @@ class NameIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @ParameterizedTest(name = "k8sResource {0} configured name = {1}")
@@ -69,7 +73,11 @@ class NameIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/NamespaceIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/NamespaceIT.java
@@ -56,7 +56,12 @@ class NamespaceIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/namespace-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @ParameterizedTest(name = "{0} : jkube.namespace = {1}, jkube.enricher.jkube-namespace.namespace={2}")
@@ -74,6 +79,11 @@ class NamespaceIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/namespace-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/OpenLibertyIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/OpenLibertyIT.java
@@ -43,7 +43,13 @@ class OpenLibertyIT {
         .contains("jkube-healthcheck-openliberty: Adding liveness probe on port 9080")
         .contains("jkube-healthcheck-openliberty: Adding startup probe on port 9080")
         .contains("jkube-service-discovery: Using first mentioned service port '9080' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/openliberty-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/openliberty-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -63,6 +69,13 @@ class OpenLibertyIT {
         .contains("jkube-healthcheck-openliberty: Adding liveness probe on port 9080")
         .contains("jkube-healthcheck-openliberty: Adding startup probe on port 9080")
         .contains("jkube-service-discovery: Using first mentioned service port '9080' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/openliberty-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/openliberty-route.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/openliberty-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProbesGroovyDSLIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProbesGroovyDSLIT.java
@@ -43,7 +43,13 @@ class ProbesGroovyDSLIT {
         .contains("jkube-controller: Adding a default Deployment")
         .contains("jkube-service: Adding a default service")
         .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/probes-groovy-dsl-config-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/probes-groovy-dsl-config-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @ParameterizedTest(name = "{0}")
@@ -62,6 +68,13 @@ class ProbesGroovyDSLIT {
         .contains("jkube-service: Adding a default service")
         .contains("jkube-openshift-deploymentconfig: Converting Deployment to DeploymentConfig")
         .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/probes-groovy-dsl-config-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/probes-groovy-dsl-config-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/probes-groovy-dsl-config-route.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProjectLabelIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ProjectLabelIT.java
@@ -61,7 +61,13 @@ class ProjectLabelIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/project-label-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/project-label-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @ParameterizedTest(name = "k8sResource {0} configured project-label ")
@@ -81,6 +87,13 @@ class ProjectLabelIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/project-label-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/project-label-route.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/project-label-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/RevisionHistoryIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/RevisionHistoryIT.java
@@ -58,7 +58,12 @@ class RevisionHistoryIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to ")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/revisionhistory-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @ParameterizedTest(name = "k8sResource {0} configured limit = {1}")
@@ -78,6 +83,11 @@ class RevisionHistoryIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to ")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/revisionhistory-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/RouteIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/RouteIT.java
@@ -52,7 +52,13 @@ class RouteIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to ")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/route-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/route-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
     assertThat(gradleRunner.resolveDefaultOpenShiftResourceDir().listFiles())
         .hasSize(expectedGeneratedFiles);
   }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ServiceAccountIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ServiceAccountIT.java
@@ -59,7 +59,11 @@ class ServiceAccountIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @ParameterizedTest(name = "resource task on project = {0} with {1}")
@@ -78,6 +82,10 @@ class ServiceAccountIT {
         .contains("Using resource templates from")
         .contains("Converting Deployment to DeploymentConfig")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ServiceIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/ServiceIT.java
@@ -40,7 +40,14 @@ class ServiceIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/service-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/svc1-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/svc2-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -56,6 +63,14 @@ class ServiceIT {
         .contains("Using resource templates from")
         .contains("Adding a default Deployment")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/service-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/svc1-route.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/svc1-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/svc2-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SpringBootIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SpringBootIT.java
@@ -44,7 +44,14 @@ class SpringBootIT {
         .contains("jkube-healthcheck-spring-boot: Adding readiness probe on port 8080")
         .contains("jkube-healthcheck-spring-boot: Adding liveness probe on port 8080")
         .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generators applied: [spring-boot]")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/spring-boot-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/spring-boot-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -64,6 +71,14 @@ class SpringBootIT {
         .contains("jkube-healthcheck-spring-boot: Adding readiness probe on port 8080")
         .contains("jkube-healthcheck-spring-boot: Adding liveness probe on port 8080")
         .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generators applied: [spring-boot]")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/spring-boot-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/spring-boot-route.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/spring-boot-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SpringBootWithFragmentIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/SpringBootWithFragmentIT.java
@@ -42,7 +42,14 @@ class SpringBootWithFragmentIT {
         .contains("jkube-healthcheck-spring-boot: Adding readiness probe on port 8080")
         .contains("jkube-healthcheck-spring-boot: Adding liveness probe on port 8080")
         .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generators applied: [spring-boot]")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/spring-boot-with-fragment-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/spring-boot-with-fragment-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -61,6 +68,14 @@ class SpringBootWithFragmentIT {
         .contains("jkube-healthcheck-spring-boot: Adding readiness probe on port 8080")
         .contains("jkube-healthcheck-spring-boot: Adding liveness probe on port 8080")
         .contains("jkube-service-discovery: Using first mentioned service port '8080' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generators applied: [spring-boot]")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/spring-boot-with-fragment-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/spring-boot-with-fragment-route.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/spring-boot-with-fragment-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/TriggersAnnotationIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/TriggersAnnotationIT.java
@@ -40,7 +40,12 @@ class TriggersAnnotationIT {
         .contains("Using resource templates from")
         .contains("Adding a default ReplicaSet")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/triggersannotation-replicaset.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @Test
@@ -56,6 +61,11 @@ class TriggersAnnotationIT {
         .contains("Using resource templates from")
         .contains("Adding a default ReplicaSet")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/triggersannotation-replicaset.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/VertxIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/VertxIT.java
@@ -70,7 +70,14 @@ class VertxIT {
         .contains("jkube-healthcheck-vertx: Adding readiness probe on port 8888")
         .contains("jkube-healthcheck-vertx: Adding liveness probe on port 8888")
         .contains("jkube-service-discovery: Using first mentioned service port '8888' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generators applied: [vertx]")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/vertx-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/vertx-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @ParameterizedTest(name = "resource task with {0} generates deployment with liveness and readiness probes")
@@ -95,6 +102,13 @@ class VertxIT {
         .contains("jkube-healthcheck-vertx: Adding readiness probe on port 8888")
         .contains("jkube-healthcheck-vertx: Adding liveness probe on port 8888")
         .contains("jkube-service-discovery: Using first mentioned service port '8888' ")
-        .contains("jkube-revision-history: Adding revision history limit to 2");
+        .contains("jkube-revision-history: Adding revision history limit to 2")
+        .contains("SUMMARY")
+        .contains("Generators applied: [vertx]")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/vertx-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/vertx-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/VolumePermissionIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/VolumePermissionIT.java
@@ -58,7 +58,14 @@ class VolumePermissionIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/jkube-docker-registry-deployment.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/jkube-docker-registry-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes/jkube-docker-registry-storage-persistentvolumeclaim.yml")
+        .contains("build/classes/java/main/META-INF/jkube/kubernetes.yml")
+        .contains("SUCCESS");
   }
 
   @ParameterizedTest(name = "{0} : jkube.enricher.jkube-volume-permission.defaultStorageClass={1}")
@@ -77,6 +84,14 @@ class VolumePermissionIT {
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")
         .contains("Adding revision history limit to 2")
-        .contains("validating");
+        .contains("validating")
+        .contains("SUMMARY")
+        .contains("Generated resources:")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/jkube-docker-registry-deploymentconfig.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/jkube-docker-registry-route.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/jkube-docker-registry-service.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift/jkube-docker-registry-storage-persistentvolumeclaim.yml")
+        .contains("build/classes/java/main/META-INF/jkube/openshift.yml")
+        .contains("SUCCESS");
   }
 }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/GradleUtil.java
@@ -19,6 +19,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -102,6 +103,19 @@ public class GradleUtil {
         acc.put(e.getKey(), e.getValue());
         return acc;
       }, (acc, e) -> acc);
+  }
+
+  public static String getLastExecutingTask(Project gradleProject, Map<String, Integer> taskPrioritiesMap) {
+    List<String> tasks = gradleProject.getGradle().getStartParameter().getTaskNames().stream()
+        .filter(taskPrioritiesMap::containsKey)
+        .sorted(Comparator.comparing(taskPrioritiesMap::get))
+        .collect(Collectors.toList());
+
+    if (tasks == null || tasks.isEmpty()) {
+      return null;
+    }
+
+    return tasks.get(tasks.size() - 1);
   }
 
   private static List<Dependency> extractDependencies(Project gradleProject) {

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/KubernetesExtension.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/KubernetesExtension.java
@@ -261,6 +261,8 @@ public abstract class KubernetesExtension {
 
   public abstract Property<String> getWatchContainerNamePattern();
 
+  public abstract Property<Boolean> getSummaryEnabled();
+
   public WatchMode watchMode;
 
   public JKubeBuildStrategy buildStrategy;
@@ -732,6 +734,10 @@ public abstract class KubernetesExtension {
 
   public String getWatchShowLogsOrNull() {
     return getOrDefaultString("jkube.watch.showLogs", this::getWatchShowLogs, null);
+  }
+
+  public boolean getSummaryEnabledOrDefault() {
+    return getOrDefaultBoolean("jkube.summaryEnabled", this::getSummaryEnabled, true);
   }
 
   protected boolean getOrDefaultBoolean(String property, Supplier<Property<Boolean>> dslGetter, boolean defaultValue) {

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
@@ -30,6 +30,7 @@ import org.eclipse.jkube.kit.build.service.docker.config.handler.ImageConfigReso
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.RegistryConfig;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.access.ClusterConfiguration;
@@ -72,6 +73,11 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
         return;
     }
     run();
+    String lastExecutingTask = GradleUtil.getLastExecutingTask(getProject(), getTaskPrioritiesMap());
+    if (lastExecutingTask != null && lastExecutingTask.equals(getName())) {
+      SummaryUtil.printSummary(kubernetesExtension.javaProject.getBaseDirectory(), kubernetesExtension.getSummaryEnabledOrDefault());
+      SummaryUtil.clear();
+    }
   }
 
   private void init() {
@@ -83,6 +89,8 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
     jKubeServiceHub = initJKubeServiceHubBuilder().build();
     kubernetesExtension.resources = updateResourceConfigNamespace(kubernetesExtension.getNamespaceOrNull(), kubernetesExtension.resources);
     ImageConfigResolver imageConfigResolver = new ImageConfigResolver();
+    SummaryUtil.initSummary(kubernetesExtension.javaProject.getBuildDirectory(), kitLogger);
+    SummaryUtil.setSuccessful(true);
     try {
       resolvedImages = resolveImages(imageConfigResolver);
       final JKubeEnricherContext context = JKubeEnricherContext.builder()

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
@@ -22,7 +22,6 @@ import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.service.ApplyService;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 
@@ -33,6 +32,8 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil.resolveFallbackNamespace;
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.printSummary;
 
 @SuppressWarnings("CdiInjectionPointsInspection")
 public class KubernetesApplyTask extends AbstractJKubeTask {
@@ -63,15 +64,13 @@ public class KubernetesApplyTask extends AbstractJKubeTask {
       kitLogger.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up",
           clusterAccess.isOpenShift() ? "oc" : "kubectl");
     } catch (KubernetesClientException e) {
-      KubernetesResourceUtil.handleKubernetesClientException(e, kitLogger, kubernetesExtension.getSummaryEnabledOrDefault());
+      IllegalStateException illegalStateException = KubernetesResourceUtil.handleKubernetesClientException(e, kitLogger, jKubeServiceHub.getSummaryService());
+      printSummary(jKubeServiceHub);
+      throw illegalStateException;
     } catch (IOException ioException) {
       kitLogger.error("Error in loading Kubernetes Manifests ", ioException);
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(), ioException.getMessage(), () -> new IllegalStateException(ioException));
-    } catch (InterruptedException interruptedException) {
-      Thread.currentThread().interrupt();
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
-          interruptedException.getMessage(),
-          () -> new IllegalStateException(interruptedException.getMessage(), interruptedException));
+      handleExceptionAndSummary(jKubeServiceHub, ioException);
+      throw new IllegalStateException(ioException);
     }
   }
 
@@ -80,7 +79,7 @@ public class KubernetesApplyTask extends AbstractJKubeTask {
     return super.shouldSkip() || kubernetesExtension.getSkipApplyOrDefault();
   }
 
-  private void applyEntities(String fileName, final Collection<HasMetadata> entities) throws InterruptedException {
+  private void applyEntities(String fileName, final Collection<HasMetadata> entities) {
     KitLogger serviceLogger = createLogger("[[G]][SVC][[G]] [[s]]");
     applyService.applyEntities(fileName, entities, serviceLogger, kubernetesExtension.getServiceUrlWaitTimeSecondsOrDefault());
   }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTask.java
@@ -22,6 +22,7 @@ import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.service.ApplyService;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 
@@ -62,13 +63,15 @@ public class KubernetesApplyTask extends AbstractJKubeTask {
       kitLogger.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up",
           clusterAccess.isOpenShift() ? "oc" : "kubectl");
     } catch (KubernetesClientException e) {
-      KubernetesResourceUtil.handleKubernetesClientException(e, kitLogger);
+      KubernetesResourceUtil.handleKubernetesClientException(e, kitLogger, kubernetesExtension.getSummaryEnabledOrDefault());
     } catch (IOException ioException) {
       kitLogger.error("Error in loading Kubernetes Manifests ", ioException);
-      throw new IllegalStateException(ioException);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(), ioException.getMessage(), () -> new IllegalStateException(ioException));
     } catch (InterruptedException interruptedException) {
       Thread.currentThread().interrupt();
-      throw new IllegalStateException(interruptedException.getMessage(), interruptedException);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
+          interruptedException.getMessage(),
+          () -> new IllegalStateException(interruptedException.getMessage(), interruptedException));
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTask.java
@@ -17,7 +17,6 @@ import javax.inject.Inject;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
@@ -30,6 +29,7 @@ import java.io.IOException;
 import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestamp;
 import static org.eclipse.jkube.kit.common.util.BuildReferenceDateUtil.getBuildTimestampFile;
 import static org.eclipse.jkube.kit.common.util.EnvUtil.storeTimestamp;
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
 
 @SuppressWarnings("CdiInjectionPointsInspection")
 public class KubernetesBuildTask extends AbstractJKubeTask {
@@ -66,8 +66,8 @@ public class KubernetesBuildTask extends AbstractJKubeTask {
       jKubeServiceHub.getBuildService().build(resolvedImages.toArray(new ImageConfiguration[0]));
     } catch (JKubeServiceException | IOException e) {
       kitLogger.error(e.getMessage());
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
-          e.getMessage(), () -> new GradleException(e.getMessage(), e));
+      handleExceptionAndSummary(jKubeServiceHub, e);
+      throw new GradleException(e.getMessage(), e);
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTask.java
@@ -17,6 +17,7 @@ import javax.inject.Inject;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
@@ -65,7 +66,8 @@ public class KubernetesBuildTask extends AbstractJKubeTask {
       jKubeServiceHub.getBuildService().build(resolvedImages.toArray(new ImageConfiguration[0]));
     } catch (JKubeServiceException | IOException e) {
       kitLogger.error(e.getMessage());
-      throw new GradleException(e.getMessage(), e);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
+          e.getMessage(), () -> new GradleException(e.getMessage(), e));
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesDebugTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesDebugTask.java
@@ -24,7 +24,6 @@ import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.gradle.api.GradleException;
 
 public class KubernetesDebugTask extends AbstractJKubeTask {
@@ -46,9 +45,7 @@ public class KubernetesDebugTask extends AbstractJKubeTask {
           "" + kubernetesExtension.getLocalDebugPortOrDefault(), kubernetesExtension.getDebugSuspendOrDefault(),
           createLogger("[[Y]][W][[Y]] [[s]]"));
     } catch (IOException ex) {
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
-          ex.getMessage(),
-          () -> new GradleException("Failure in debug task", ex));
+      throw new GradleException("Failure in debug task", ex);
     }
   }
 }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesDebugTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesDebugTask.java
@@ -24,6 +24,7 @@ import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.gradle.api.GradleException;
 
 public class KubernetesDebugTask extends AbstractJKubeTask {
@@ -45,7 +46,9 @@ public class KubernetesDebugTask extends AbstractJKubeTask {
           "" + kubernetesExtension.getLocalDebugPortOrDefault(), kubernetesExtension.getDebugSuspendOrDefault(),
           createLogger("[[Y]][W][[Y]] [[s]]"));
     } catch (IOException ex) {
-      throw new GradleException("Failure in debug task", ex);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
+          ex.getMessage(),
+          () -> new GradleException("Failure in debug task", ex));
     }
   }
 }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmPushTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmPushTask.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.resource.helm.HelmConfig;
 
 import javax.inject.Inject;
@@ -41,7 +42,9 @@ public class KubernetesHelmPushTask extends AbstractJKubeTask {
       jKubeServiceHub.getHelmService().uploadHelmChart(helm);
     } catch (Exception exp) {
       kitLogger.error("Error performing helm push", exp);
-      throw new IllegalStateException(exp.getMessage(), exp);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
+          exp.getMessage(),
+          () -> new IllegalStateException(exp.getMessage(), exp));
     }
   }
 }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmPushTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmPushTask.java
@@ -14,11 +14,11 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.resource.helm.HelmConfig;
 
 import javax.inject.Inject;
 
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
 import static org.eclipse.jkube.kit.resource.helm.HelmServiceUtil.initHelmConfig;
 import static org.eclipse.jkube.kit.resource.helm.HelmServiceUtil.initHelmPushConfig;
 
@@ -42,9 +42,8 @@ public class KubernetesHelmPushTask extends AbstractJKubeTask {
       jKubeServiceHub.getHelmService().uploadHelmChart(helm);
     } catch (Exception exp) {
       kitLogger.error("Error performing helm push", exp);
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
-          exp.getMessage(),
-          () -> new IllegalStateException(exp.getMessage(), exp));
+      handleExceptionAndSummary(jKubeServiceHub, exp);
+      throw new IllegalStateException(exp.getMessage(), exp);
     }
   }
 }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmTask.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.resource.helm.HelmConfig;
 
 import javax.inject.Inject;
@@ -41,7 +42,9 @@ public class KubernetesHelmTask extends AbstractJKubeTask {
         kubernetesExtension.helm).build();
       jKubeServiceHub.getHelmService().generateHelmCharts(helm);
     } catch (IOException exception) {
-      throw new IllegalStateException(exception.getMessage(), exception);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
+          exception.getMessage(),
+          () -> new IllegalStateException(exception.getMessage(), exception));
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmTask.java
@@ -14,13 +14,13 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.resource.helm.HelmConfig;
 
 import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
 import static org.eclipse.jkube.kit.resource.helm.HelmServiceUtil.initHelmConfig;
 
 public class KubernetesHelmTask extends AbstractJKubeTask {
@@ -42,9 +42,8 @@ public class KubernetesHelmTask extends AbstractJKubeTask {
         kubernetesExtension.helm).build();
       jKubeServiceHub.getHelmService().generateHelmCharts(helm);
     } catch (IOException exception) {
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
-          exception.getMessage(),
-          () -> new IllegalStateException(exception.getMessage(), exception));
+      handleExceptionAndSummary(jKubeServiceHub, exception);
+      throw new IllegalStateException(exception.getMessage(), exception);
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesJKubeTask.java
@@ -16,6 +16,10 @@ package org.eclipse.jkube.gradle.plugin.task;
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.gradle.api.tasks.Internal;
 
+import java.util.HashMap;
+import java.util.Map;
+
+
 public interface KubernetesJKubeTask extends JKubeTask {
 
   String DEFAULT_LOG_PREFIX = "k8s: ";
@@ -25,5 +29,21 @@ public interface KubernetesJKubeTask extends JKubeTask {
   @Internal
   default String getLogPrefix() {
     return DEFAULT_LOG_PREFIX;
+  }
+
+  @Internal
+  default Map<String, Integer> getTaskPrioritiesMap() {
+    Map<String, Integer> kubernetesPluginTaskPriorities = new HashMap<>();
+    kubernetesPluginTaskPriorities.put("k8sBuild", 1);
+    kubernetesPluginTaskPriorities.put("k8sResource", 2);
+    kubernetesPluginTaskPriorities.put("k8sPush", 2);
+    kubernetesPluginTaskPriorities.put("k8sHelm", 3);
+    kubernetesPluginTaskPriorities.put("k8sHelmPush", 4);
+    kubernetesPluginTaskPriorities.put("k8sApply", 5);
+    kubernetesPluginTaskPriorities.put("k8sLog", 6);
+    kubernetesPluginTaskPriorities.put("k8sDebug", 6);
+    kubernetesPluginTaskPriorities.put("k8sWatch", 6);
+    kubernetesPluginTaskPriorities.put("k8sUndeploy", 7);
+    return kubernetesPluginTaskPriorities;
   }
 }

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTask.java
@@ -20,6 +20,7 @@ import javax.inject.Inject;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.service.PodLogService;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -50,7 +51,9 @@ public class KubernetesLogTask extends AbstractJKubeTask {
           null,
           true);
     } catch (IOException exception) {
-      throw new GradleException("Failure in getting logs", exception);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
+          exception.getMessage(),
+          () -> new GradleException("Failure in getting logs", exception));
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTask.java
@@ -20,7 +20,6 @@ import javax.inject.Inject;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.service.PodLogService;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -51,9 +50,7 @@ public class KubernetesLogTask extends AbstractJKubeTask {
           null,
           true);
     } catch (IOException exception) {
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
-          exception.getMessage(),
-          () -> new GradleException("Failure in getting logs", exception));
+      throw new GradleException("Failure in getting logs", exception);
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.gradle.plugin.task;
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
 import org.eclipse.jkube.kit.common.RegistryConfig;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceException;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
@@ -44,7 +45,9 @@ public class KubernetesPushTask extends AbstractJKubeTask {
       jKubeServiceHub.getBuildService()
           .push(resolvedImages, kubernetesExtension.getPushRetriesOrDefault(), initRegistryConfig(), kubernetesExtension.getSkipTagOrDefault());
     } catch (JKubeServiceException e) {
-      throw new IllegalStateException("Error in pushing image: " + e.getMessage(), e);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
+          e.getMessage(),
+          () -> new IllegalStateException("Error in pushing image: " + e.getMessage(), e));
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
@@ -16,13 +16,14 @@ package org.eclipse.jkube.gradle.plugin.task;
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
 import org.eclipse.jkube.kit.common.RegistryConfig;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceException;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 
 import javax.inject.Inject;
 import java.util.Collections;
+
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
 
 public class KubernetesPushTask extends AbstractJKubeTask {
   @Inject
@@ -45,9 +46,8 @@ public class KubernetesPushTask extends AbstractJKubeTask {
       jKubeServiceHub.getBuildService()
           .push(resolvedImages, kubernetesExtension.getPushRetriesOrDefault(), initRegistryConfig(), kubernetesExtension.getSkipTagOrDefault());
     } catch (JKubeServiceException e) {
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
-          e.getMessage(),
-          () -> new IllegalStateException("Error in pushing image: " + e.getMessage(), e));
+      handleExceptionAndSummary(jKubeServiceHub, e);
+      throw new IllegalStateException("Error in pushing image: " + e.getMessage(), e);
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesResourceTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesResourceTask.java
@@ -19,6 +19,7 @@ import javax.validation.ConstraintViolationException;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.kit.common.util.LazyBuilder;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 import org.eclipse.jkube.kit.config.resource.ResourceServiceConfig;
@@ -92,7 +93,9 @@ public class KubernetesResourceTask extends AbstractJKubeTask {
         validateIfRequired(resourceClassifierDir, resourceClassifier);
       }
     } catch (IOException e) {
-      throw new IllegalStateException("Failed to generate kubernetes descriptor", e);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
+          e.getMessage(),
+          () -> new IllegalStateException("Failed to generate kubernetes descriptor", e));
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 
 import javax.inject.Inject;
@@ -44,7 +45,9 @@ public class KubernetesUndeployTask extends AbstractJKubeTask {
       jKubeServiceHub.getUndeployService()
         .undeploy(environmentResourceDirs, resources, findManifestsToUndeploy().toArray(new File[0]));
     } catch (IOException e) {
-      throw new IllegalStateException(e.getMessage(), e);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
+          e.getMessage(),
+          () -> new IllegalStateException(e.getMessage(), e));
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTask.java
@@ -14,7 +14,6 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 
 import javax.inject.Inject;
@@ -23,6 +22,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
 
 public class KubernetesUndeployTask extends AbstractJKubeTask {
 
@@ -45,9 +46,8 @@ public class KubernetesUndeployTask extends AbstractJKubeTask {
       jKubeServiceHub.getUndeployService()
         .undeploy(environmentResourceDirs, resources, findManifestsToUndeploy().toArray(new File[0]));
     } catch (IOException e) {
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
-          e.getMessage(),
-          () -> new IllegalStateException(e.getMessage(), e));
+      handleExceptionAndSummary(jKubeServiceHub, e);
+      throw new IllegalStateException(e.getMessage(), e);
     }
   }
 

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
@@ -23,6 +23,7 @@ import org.eclipse.jkube.kit.build.service.docker.access.log.LogDispatcher;
 import org.eclipse.jkube.kit.build.service.docker.watch.WatchContext;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
@@ -68,9 +69,11 @@ public class KubernetesWatchTask extends AbstractJKubeTask {
             resources,
             context);
       } catch (KubernetesClientException kubernetesClientException) {
-        KubernetesResourceUtil.handleKubernetesClientException(kubernetesClientException, kitLogger);
+        KubernetesResourceUtil.handleKubernetesClientException(kubernetesClientException, kitLogger, kubernetesExtension.getSummaryEnabledOrDefault());
       } catch (Exception ioException) {
-        throw new IllegalStateException("An error has occurred while while trying to watch the resources", ioException);
+        SummaryUtil.setFailureIfSummaryEnabledOrThrow(kubernetesExtension.getSummaryEnabledOrDefault(),
+            ioException.getMessage(),
+            () -> new IllegalStateException("An error has occurred while while trying to watch the resources", ioException));
       }
     }
   }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/TestKubernetesExtension.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/TestKubernetesExtension.java
@@ -391,4 +391,9 @@ public class TestKubernetesExtension extends KubernetesExtension {
   public Property<String> getWatchContainerNamePattern() {
     return new DefaultProperty<>(String.class);
   }
+
+  @Override
+  public Property<Boolean> getSummaryEnabled() {
+    return new DefaultProperty<>(Boolean.class);
+  }
 }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesApplyTaskTest.java
@@ -17,9 +17,11 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.Collections;
 
+import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.gradle.plugin.TestKubernetesExtension;
+import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.service.ApplyService;
 
@@ -30,14 +32,19 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -48,7 +55,6 @@ class KubernetesApplyTaskTest {
   private final TaskEnvironmentExtension taskEnvironment = new TaskEnvironmentExtension();
 
   private MockedConstruction<ClusterAccess> clusterAccessMockedConstruction;
-  private MockedConstruction<ApplyService> applyServiceMockedConstruction;
   private TestKubernetesExtension extension;
 
   @BeforeEach
@@ -60,7 +66,6 @@ class KubernetesApplyTaskTest {
       when(kubernetesClient.adapt(OpenShiftClient.class)).thenReturn(kubernetesClient);
       when(mock.createDefaultClient()).thenReturn(kubernetesClient);
     });
-    applyServiceMockedConstruction = mockConstruction(ApplyService.class);
     extension = new TestKubernetesExtension();
     when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
     extension.isFailOnNoKubernetesJson = false;
@@ -68,7 +73,6 @@ class KubernetesApplyTaskTest {
 
   @AfterEach
   void tearDown() {
-    applyServiceMockedConstruction.close();
     clusterAccessMockedConstruction.close();
   }
 
@@ -97,58 +101,121 @@ class KubernetesApplyTaskTest {
 
   @Test
   void configureApplyService_withManifest_shouldSetDefaults() throws Exception {
-    // Given
-    taskEnvironment.withKubernetesManifest();
-    final KubernetesApplyTask applyTask = new KubernetesApplyTask(KubernetesExtension.class);
-    // When
-    applyTask.runTask();
-    // Then
-    final ApplyService as = applyServiceMockedConstruction.constructed().iterator().next();
-    verify(as, times(1)).setAllowCreate(true);
-    verify(as, times(1)).setServicesOnlyMode(false);
-    verify(as, times(1)).setIgnoreServiceMode(false);
-    verify(as, times(1)).setLogJsonDir(any());
-    verify(as, times(1)).setBasedir(taskEnvironment.getRoot());
-    verify(as, times(1)).setSupportOAuthClients(false);
-    verify(as, times(1)).setIgnoreRunningOAuthClients(true);
-    verify(as, times(1)).setProcessTemplatesLocally(true);
-    verify(as, times(1)).setDeletePodsOnReplicationControllerUpdate(true);
-    verify(as, times(1)).setRollingUpgrade(false);
-    verify(as, times(1)).setRollingUpgradePreserveScale(false);
-    verify(as, times(1)).setRecreateMode(false);
-    verify(as, times(1)).setNamespace(null);
-    verify(as, times(1)).setFallbackNamespace(null);
+    try (MockedConstruction<ApplyService> applyServiceMockedConstruction = mockConstruction(ApplyService.class)) {
+      // Given
+      taskEnvironment.withKubernetesManifest();
+      final KubernetesApplyTask applyTask = new KubernetesApplyTask(KubernetesExtension.class);
+      // When
+      applyTask.runTask();
+      // Then
+      final ApplyService as = applyServiceMockedConstruction.constructed().iterator().next();
+      verify(as, times(1)).setAllowCreate(true);
+      verify(as, times(1)).setServicesOnlyMode(false);
+      verify(as, times(1)).setIgnoreServiceMode(false);
+      verify(as, times(1)).setLogJsonDir(any());
+      verify(as, times(1)).setBasedir(taskEnvironment.getRoot());
+      verify(as, times(1)).setSupportOAuthClients(false);
+      verify(as, times(1)).setIgnoreRunningOAuthClients(true);
+      verify(as, times(1)).setProcessTemplatesLocally(true);
+      verify(as, times(1)).setDeletePodsOnReplicationControllerUpdate(true);
+      verify(as, times(1)).setRollingUpgrade(false);
+      verify(as, times(1)).setRollingUpgradePreserveScale(false);
+      verify(as, times(1)).setRecreateMode(false);
+      verify(as, times(1)).setNamespace(null);
+      verify(as, times(1)).setFallbackNamespace(null);
+    }
+  }
+
+  @Test
+  void configureApplySerVvice_withManifest_shouldSetDefaults() throws Exception {
+    try (MockedConstruction<ApplyService> applyServiceMockedConstruction = mockConstruction(ApplyService.class)) {
+      // Given
+      taskEnvironment.withKubernetesManifest();
+      final KubernetesApplyTask applyTask = new KubernetesApplyTask(KubernetesExtension.class);
+      // When
+      applyTask.runTask();
+      // Then
+      final ApplyService as = applyServiceMockedConstruction.constructed().iterator().next();
+      verify(as, times(1)).setAllowCreate(true);
+      verify(as, times(1)).setServicesOnlyMode(false);
+      verify(as, times(1)).setIgnoreServiceMode(false);
+      verify(as, times(1)).setLogJsonDir(any());
+      verify(as, times(1)).setBasedir(taskEnvironment.getRoot());
+      verify(as, times(1)).setSupportOAuthClients(false);
+      verify(as, times(1)).setIgnoreRunningOAuthClients(true);
+      verify(as, times(1)).setProcessTemplatesLocally(true);
+      verify(as, times(1)).setDeletePodsOnReplicationControllerUpdate(true);
+      verify(as, times(1)).setRollingUpgrade(false);
+      verify(as, times(1)).setRollingUpgradePreserveScale(false);
+      verify(as, times(1)).setRecreateMode(false);
+      verify(as, times(1)).setNamespace(null);
+      verify(as, times(1)).setFallbackNamespace(null);
+    }
   }
 
   @Test
   void runTask_withManifest_shouldApplyEntities() throws Exception {
-    // Given
-    taskEnvironment.withKubernetesManifest();
-    final KubernetesApplyTask applyTask = new KubernetesApplyTask(KubernetesExtension.class);
-    // When
-    applyTask.runTask();
-    // Then
-    assertThat(applyServiceMockedConstruction.constructed()).hasSize(1);
-    verify(applyServiceMockedConstruction.constructed().iterator().next(), times(1))
-        .applyEntities(any(), eq(Collections.emptyList()), any(), eq(5L));
+    try (MockedConstruction<ApplyService> applyServiceMockedConstruction = mockConstruction(ApplyService.class)) {
+      // Given
+      taskEnvironment.withKubernetesManifest();
+      final KubernetesApplyTask applyTask = new KubernetesApplyTask(KubernetesExtension.class);
+      // When
+      applyTask.runTask();
+      // Then
+      assertThat(applyServiceMockedConstruction.constructed()).hasSize(1);
+      verify(applyServiceMockedConstruction.constructed().iterator().next(), times(1))
+          .applyEntities(any(), eq(Collections.emptyList()), any(), eq(5L));
+    }
   }
 
   @Test
   void runTask_withSkipApply_shouldDoNothing() {
-    // Given
-    extension = new TestKubernetesExtension() {
-      @Override
-      public Property<Boolean> getSkipApply() {
-        return new DefaultProperty<>(Boolean.class).value(true);
-      }
-    };
-    when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
-    final KubernetesApplyTask applyTask = new KubernetesApplyTask(KubernetesExtension.class);
+    try (MockedConstruction<ApplyService> applyServiceMockedConstruction = mockConstruction(ApplyService.class)) {
+      // Given
+      extension = new TestKubernetesExtension() {
+        @Override
+        public Property<Boolean> getSkipApply() {
+          return new DefaultProperty<>(Boolean.class).value(true);
+        }
+      };
+      when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
+      final KubernetesApplyTask applyTask = new KubernetesApplyTask(KubernetesExtension.class);
 
-    // When
-    applyTask.runTask();
+      // When
+      applyTask.runTask();
 
-    // Then
-    assertThat(applyServiceMockedConstruction.constructed()).isEmpty();
+      // Then
+      assertThat(applyServiceMockedConstruction.constructed()).isEmpty();
+    }
+  }
+
+  @Test
+  void runTask_whenApplyServiceFails_thenExceptionThrown() {
+    try (MockedConstruction<ApplyService> applyServiceMockedConstruction = mockConstruction(ApplyService.class, (mock, ctx) -> {
+      doThrow(new KubernetesClientException("failure")).when(mock).applyEntities(anyString(), any(), any(), anyLong());
+    })) {
+      // Given
+      final KubernetesApplyTask applyTask = new KubernetesApplyTask(KubernetesExtension.class);
+
+      // When + Then
+      assertThatIllegalStateException()
+          .isThrownBy(applyTask::runTask)
+          .withMessage("failure");
+      assertThat(applyServiceMockedConstruction.constructed()).hasSize(1);
+    }
+  }
+
+  @Test
+  void runTask_whenLoadingManifestFails_thenExceptionThrown() {
+    try (MockedStatic<KubernetesHelper> kubernetesHelperMockedStatic = mockStatic(KubernetesHelper.class)) {
+      // Given
+      kubernetesHelperMockedStatic.when(() -> KubernetesHelper.loadResources(any())).thenThrow(new IOException("failure"));
+      final KubernetesApplyTask applyTask = new KubernetesApplyTask(KubernetesExtension.class);
+
+      // When + Then
+      assertThatIllegalStateException()
+          .isThrownBy(applyTask::runTask)
+          .withMessageContaining("failure");
+    }
   }
 }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTaskTest.java
@@ -112,6 +112,13 @@ class KubernetesBuildTaskTest {
   void runTask_withImageConfigurationAndBuildError_shouldThrowException() {
     // Given
     isBuildError = true;
+    extension = new TestKubernetesExtension() {
+      @Override
+      public Property<Boolean> getSummaryEnabled() {
+        return new DefaultProperty<>(Boolean.class).value(false);
+      }
+    };
+    when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
     final KubernetesBuildTask buildTask = new KubernetesBuildTask(KubernetesExtension.class);
     // When & Then
     assertThatExceptionOfType(GradleException.class)

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesLogTaskTest.java
@@ -23,6 +23,8 @@ import org.gradle.api.GradleException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.provider.Property;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -61,6 +63,13 @@ class KubernetesLogTaskTest {
   @Test
   void runTask_withNoManifestAndFailure_shouldThrowException() {
     // Given
+    extension = new TestKubernetesExtension() {
+      @Override
+      public Property<Boolean> getSummaryEnabled() {
+        return new DefaultProperty<>(Boolean.class).value(false);
+      }
+    };
+    when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
     extension.isFailOnNoKubernetesJson = true;
     final KubernetesLogTask kubernetesLogTask = new KubernetesLogTask(KubernetesExtension.class);
     // When & Then
@@ -74,6 +83,13 @@ class KubernetesLogTaskTest {
     try (MockedStatic<KubernetesHelper> mockStatic = Mockito.mockStatic(KubernetesHelper.class)) {
       // Given
       mockStatic.when(() -> KubernetesHelper.loadResources(any())).thenThrow(new IOException("IO error with logs"));
+      extension = new TestKubernetesExtension() {
+        @Override
+        public Property<Boolean> getSummaryEnabled() {
+          return new DefaultProperty<>(Boolean.class).value(false);
+        }
+      };
+      when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
       KubernetesLogTask kubernetesLogTask = new KubernetesLogTask(KubernetesExtension.class);
       // When & Then
       assertThatExceptionOfType(GradleException.class)

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesUndeployTaskTest.java
@@ -35,6 +35,9 @@ import org.mockito.MockedConstruction;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.times;
@@ -46,7 +49,6 @@ class KubernetesUndeployTaskTest {
   @RegisterExtension
   private final TaskEnvironmentExtension taskEnvironment = new TaskEnvironmentExtension();
 
-  private MockedConstruction<KubernetesUndeployService> kubernetesUndeployServiceMockedConstruction;
   private MockedConstruction<ClusterAccess> clusterAccessMockedConstruction;
   private TestKubernetesExtension extension;
 
@@ -57,14 +59,12 @@ class KubernetesUndeployTaskTest {
       when(mock.createDefaultClient()).thenReturn(kubernetesClient);
       when(kubernetesClient.getMasterUrl()).thenReturn(new URL("http://kubernetes-cluster"));
     });
-    kubernetesUndeployServiceMockedConstruction = mockConstruction(KubernetesUndeployService.class);
     extension = new TestKubernetesExtension();
     when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
   }
 
   @AfterEach
   void tearDown() {
-    kubernetesUndeployServiceMockedConstruction.close();
     clusterAccessMockedConstruction.close();
   }
 
@@ -83,38 +83,58 @@ class KubernetesUndeployTaskTest {
   @Test
   void runTask_withOfflineTrue_shouldUndeployResources() throws IOException {
     // Given
-    final KubernetesUndeployTask undeployTask = new KubernetesUndeployTask(KubernetesExtension.class);
+    try (MockedConstruction<KubernetesUndeployService> kubernetesUndeployServiceMockedConstruction = mockConstruction(KubernetesUndeployService.class)) {
+      // Given
+      final KubernetesUndeployTask undeployTask = new KubernetesUndeployTask(KubernetesExtension.class);
 
-    // When
-    undeployTask.runTask();
+      // When
+      undeployTask.runTask();
 
-    // Then
-    assertThat(kubernetesUndeployServiceMockedConstruction.constructed()).hasSize(1);
-    verify(kubernetesUndeployServiceMockedConstruction.constructed().iterator().next(), times(1))
-      .undeploy(
-            Collections.singletonList(taskEnvironment.getRoot().toPath().resolve(Paths.get("src", "main", "jkube"))
-                .toFile()),
-            ResourceConfig.builder().build(), taskEnvironment.getRoot().toPath()
-                .resolve(Paths.get("build", "classes", "java", "main", "META-INF", "jkube", "kubernetes.yml")).toFile()
-      );
+      // Then
+      assertThat(kubernetesUndeployServiceMockedConstruction.constructed()).hasSize(1);
+      verify(kubernetesUndeployServiceMockedConstruction.constructed().iterator().next(), times(1))
+          .undeploy(
+              Collections.singletonList(taskEnvironment.getRoot().toPath().resolve(Paths.get("src", "main", "jkube"))
+                  .toFile()),
+              ResourceConfig.builder().build(), taskEnvironment.getRoot().toPath()
+                  .resolve(Paths.get("build", "classes", "java", "main", "META-INF", "jkube", "kubernetes.yml")).toFile()
+          );
+    }
   }
 
   @Test
   void runTask_withSkipUndeploy_shouldDoNothing() {
-    // Given
-    extension = new TestKubernetesExtension() {
-      @Override
-      public Property<Boolean> getSkipUndeploy() {
-        return new DefaultProperty<>(Boolean.class).value(true);
-      }
-    };
-    when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
-    final KubernetesUndeployTask kubernetesUndeployTask = new KubernetesUndeployTask(KubernetesExtension.class);
+    try (MockedConstruction<KubernetesUndeployService> kubernetesUndeployServiceMockedConstruction = mockConstruction(KubernetesUndeployService.class)) {
+      // Given
+      extension = new TestKubernetesExtension() {
+        @Override
+        public Property<Boolean> getSkipUndeploy() {
+          return new DefaultProperty<>(Boolean.class).value(true);
+        }
+      };
+      when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
+      final KubernetesUndeployTask kubernetesUndeployTask = new KubernetesUndeployTask(KubernetesExtension.class);
 
-    // When
-    kubernetesUndeployTask.runTask();
+      // When
+      kubernetesUndeployTask.runTask();
 
-    // Then
-    assertThat(kubernetesUndeployServiceMockedConstruction.constructed()).isEmpty();
+      // Then
+      assertThat(kubernetesUndeployServiceMockedConstruction.constructed()).isEmpty();
+    }
+  }
+
+  @Test
+  void runTask_whenUndeployServiceFails_thenThrowException() {
+    try (MockedConstruction<KubernetesUndeployService> kubernetesUndeployServiceMockedConstruction = mockConstruction(KubernetesUndeployService.class,
+        (mock, ctx) -> doThrow(new IOException("failure")).when(mock).undeploy(any(), any(), any()))) {
+      // Given
+      final KubernetesUndeployTask kubernetesUndeployTask = new KubernetesUndeployTask(KubernetesExtension.class);
+
+      // When + Then
+      assertThatIllegalStateException()
+          .isThrownBy(kubernetesUndeployTask::runTask)
+          .withMessageContaining("failure");
+      assertThat(kubernetesUndeployServiceMockedConstruction.constructed()).isNotEmpty();
+    }
   }
 }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTaskTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.provider.Property;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
@@ -88,7 +90,14 @@ class KubernetesWatchTaskTest {
   @Test
   void runTask_withNoManifest_shouldThrowException() {
     // Given
+    extension = new TestKubernetesExtension() {
+      @Override
+      public Property<Boolean> getSummaryEnabled() {
+        return new DefaultProperty<>(Boolean.class).value(false);
+      }
+    };
     extension.isFailOnNoKubernetesJson = true;
+    when(taskEnvironment.project.getExtensions().getByType(KubernetesExtension.class)).thenReturn(extension);
     final KubernetesWatchTask watchTask = new KubernetesWatchTask(KubernetesExtension.class);
     // When & Then
     assertThatIllegalStateException()

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftJKubeTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftJKubeTask.java
@@ -16,6 +16,9 @@ package org.eclipse.jkube.gradle.plugin.task;
 import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
 import org.gradle.api.tasks.Internal;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public interface OpenShiftJKubeTask extends KubernetesJKubeTask {
 
   String DEFAULT_LOG_PREFIX = "oc: ";
@@ -29,5 +32,22 @@ public interface OpenShiftJKubeTask extends KubernetesJKubeTask {
   @Override
   default String getLogPrefix() {
     return DEFAULT_LOG_PREFIX;
+  }
+
+  @Internal
+  @Override
+  default Map<String, Integer> getTaskPrioritiesMap() {
+    Map<String, Integer> openshiftPluginTaskPrioritiesMap = new HashMap<>();
+    openshiftPluginTaskPrioritiesMap.put("ocBuild", 1);
+    openshiftPluginTaskPrioritiesMap.put("ocResource", 2);
+    openshiftPluginTaskPrioritiesMap.put("ocPush", 2);
+    openshiftPluginTaskPrioritiesMap.put("ocHelm", 3);
+    openshiftPluginTaskPrioritiesMap.put("ocHelmPush", 4);
+    openshiftPluginTaskPrioritiesMap.put("ocApply", 5);
+    openshiftPluginTaskPrioritiesMap.put("ocLog", 6);
+    openshiftPluginTaskPrioritiesMap.put("ocDebug", 6);
+    openshiftPluginTaskPrioritiesMap.put("ocWatch", 6);
+    openshiftPluginTaskPrioritiesMap.put("ocUndeploy", 7);
+    return openshiftPluginTaskPrioritiesMap;
   }
 }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/TestOpenShiftExtension.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/TestOpenShiftExtension.java
@@ -418,4 +418,9 @@ public class TestOpenShiftExtension extends OpenShiftExtension {
   public Property<String> getWatchContainerNamePattern() {
     return new DefaultProperty<>(String.class);
   }
+
+  @Override
+  public Property<Boolean> getSummaryEnabled() {
+    return new DefaultProperty<>(Boolean.class);
+  }
 }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftWatchTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftWatchTaskTest.java
@@ -23,6 +23,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.gradle.api.internal.provider.DefaultProperty;
+import org.gradle.api.provider.Property;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 
@@ -73,6 +75,13 @@ class OpenShiftWatchTaskTest {
   @Test
   void runTask_withNoManifest_shouldThrowException() {
     // Given
+    extension = new TestOpenShiftExtension() {
+      @Override
+      public Property<Boolean> getSummaryEnabled() {
+        return new DefaultProperty<>(Boolean.class).value(false);
+      }
+    };
+    when(taskEnvironment.project.getExtensions().getByType(OpenShiftExtension.class)).thenReturn(extension);
     extension.isFailOnNoKubernetesJson = true;
     final OpenShiftWatchTask watchTask = new OpenShiftWatchTask(OpenShiftExtension.class);
     // When & Then

--- a/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManager.java
+++ b/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManager.java
@@ -43,6 +43,7 @@ import org.eclipse.jkube.kit.common.archive.ArchiveCompression;
 import org.eclipse.jkube.kit.common.archive.JKubeTarArchiver;
 import org.eclipse.jkube.kit.common.util.FileUtil;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.image.build.DockerFileBuilder;
@@ -109,6 +110,7 @@ public class AssemblyManager {
 
         try {
             if (buildConfig.isDockerFileMode()) {
+                SummaryUtil.setDockerFileImageSummary(imageName, buildConfig.getDockerFileFile().getAbsolutePath());
                 createDockerTarArchiveForDockerFile(buildConfig, assemblyConfig, configuration, buildDirs, log, archiveCustomizers);
             } else {
                 createAssemblyArchive(assemblyConfig, configuration, buildDirs, buildConfig.getCompression(), layers);
@@ -472,5 +474,4 @@ public class AssemblyManager {
         }
         return includes;
     }
-
 }

--- a/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManager.java
+++ b/jkube-kit/build/api/src/main/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManager.java
@@ -41,9 +41,9 @@ import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.archive.ArchiveCompression;
 import org.eclipse.jkube.kit.common.archive.JKubeTarArchiver;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.FileUtil;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.image.build.DockerFileBuilder;
@@ -95,12 +95,13 @@ public class AssemblyManager {
      * @param buildConfig configuration for how to build the image
      * @param log KitLogger used to display warning if permissions are to be normalized
      * @param finalCustomizer finalCustomizer to be applied to the tar archive
+     * @param summaryService {@link SummaryService}
      * @return file holding the path to the created assembly tar file
      * @throws IOException IO exception
      */
     public File createDockerTarArchive(
         String imageName, final JKubeConfiguration configuration, final BuildConfiguration buildConfig, KitLogger log,
-        ArchiverCustomizer finalCustomizer) throws IOException {
+        ArchiverCustomizer finalCustomizer, SummaryService summaryService) throws IOException {
 
         final BuildDirs buildDirs = createBuildDirs(imageName, configuration);
         final List<ArchiverCustomizer> archiveCustomizers = new ArrayList<>();
@@ -110,7 +111,7 @@ public class AssemblyManager {
 
         try {
             if (buildConfig.isDockerFileMode()) {
-                SummaryUtil.setDockerFileImageSummary(imageName, buildConfig.getDockerFileFile().getAbsolutePath());
+                summaryService.setDockerFileImageSummary(imageName, buildConfig.getDockerFileFile().getAbsolutePath());
                 createDockerTarArchiveForDockerFile(buildConfig, assemblyConfig, configuration, buildDirs, log, archiveCustomizers);
             } else {
                 createAssemblyArchive(assemblyConfig, configuration, buildDirs, buildConfig.getCompression(), layers);

--- a/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManagerCreateDockerTarArchiveTest.java
+++ b/jkube-kit/build/api/src/test/java/org/eclipse/jkube/kit/build/api/assembly/AssemblyManagerCreateDockerTarArchiveTest.java
@@ -32,6 +32,7 @@ import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.PrefixedLogger;
 import org.eclipse.jkube.kit.common.assertj.ArchiveAssertions;
 import org.eclipse.jkube.kit.common.assertj.FileAssertions;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.assertj.core.api.AbstractFileAssert;
 import org.assertj.core.api.AbstractListAssert;
@@ -55,10 +56,12 @@ class AssemblyManagerCreateDockerTarArchiveTest {
   private AssemblyManager assemblyManager;
   private File baseDirectory;
   private File targetDirectory;
+  private SummaryService summaryService;
 
   @BeforeEach
   void setUp() throws IOException {
     prefixedLogger = mock(PrefixedLogger.class);
+    summaryService = mock(SummaryService.class);
     assemblyManager = AssemblyManager.getInstance();
     baseDirectory = temporaryFolder.toFile();
     targetDirectory = Files.createDirectory(temporaryFolder.resolve("target")).toFile();
@@ -93,7 +96,7 @@ class AssemblyManagerCreateDockerTarArchiveTest {
 
     // When
     File dockerArchiveFile = assemblyManager.createDockerTarArchive(
-        "test-image", jKubeConfiguration, buildConfiguration, prefixedLogger, null);
+        "test-image", jKubeConfiguration, buildConfiguration, prefixedLogger, null, summaryService);
 
     // Then
     assertTargetHasDockerDirectories("test-image");
@@ -124,7 +127,7 @@ class AssemblyManagerCreateDockerTarArchiveTest {
 
     // When
     File dockerArchiveFile = assemblyManager.createDockerTarArchive(
-        "no-docker-file-and-customizer", jKubeConfiguration, buildConfiguration, prefixedLogger, finalCustomizer);
+        "no-docker-file-and-customizer", jKubeConfiguration, buildConfiguration, prefixedLogger, finalCustomizer, summaryService);
 
     // Then
     assertTargetHasDockerDirectories("no-docker-file-and-customizer");
@@ -150,11 +153,11 @@ class AssemblyManagerCreateDockerTarArchiveTest {
 
     // When
     assemblyManager.createDockerTarArchive(
-        "modified-image", jKubeConfiguration, buildConfiguration, prefixedLogger, null);
+        "modified-image", jKubeConfiguration, buildConfiguration, prefixedLogger, null, summaryService);
     // Modify file contents
     writeLineToFile(jKubeConfiguration.getProject().getArtifact(), "Modified content");
     dockerArchiveFile = assemblyManager.createDockerTarArchive(
-        "modified-image", jKubeConfiguration, buildConfiguration, prefixedLogger, null);
+        "modified-image", jKubeConfiguration, buildConfiguration, prefixedLogger, null, summaryService);
 
     // Then
     assertTargetHasDockerDirectories("modified-image");
@@ -185,7 +188,7 @@ class AssemblyManagerCreateDockerTarArchiveTest {
         .dockerFileFile(dockerFile).dockerFile(dockerFile.getPath()).build();
 
     // When
-    File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
+    File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null, summaryService);
 
     // Then
     assertTargetHasDockerDirectories("test-image");
@@ -226,7 +229,7 @@ class AssemblyManagerCreateDockerTarArchiveTest {
 
     // When
     final File dockerArchiveFile = assemblyManager.createDockerTarArchive(
-        "dockerfile-and-assembly-file", configuration, jKubeBuildConfiguration, prefixedLogger, null);
+        "dockerfile-and-assembly-file", configuration, jKubeBuildConfiguration, prefixedLogger, null, summaryService);
 
     // Then
     assertTargetHasDockerDirectories("dockerfile-and-assembly-file");
@@ -259,7 +262,7 @@ class AssemblyManagerCreateDockerTarArchiveTest {
 
     // When
     final File dockerArchiveFile = assemblyManager.createDockerTarArchive(
-        "test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
+        "test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null, summaryService);
 
     // Then
     assertTargetHasDockerDirectories("test-image");
@@ -290,7 +293,7 @@ class AssemblyManagerCreateDockerTarArchiveTest {
 
     // When
     final File dockerArchiveFile = assemblyManager.createDockerTarArchive(
-        "test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
+        "test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null, summaryService);
 
     // Then
     assertTargetHasDockerDirectories("test-image");
@@ -323,7 +326,7 @@ class AssemblyManagerCreateDockerTarArchiveTest {
         .dockerFileFile(dockerFile).dockerFile(dockerFile.getPath()).build();
 
     // When
-    File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null);
+    File dockerArchiveFile = assemblyManager.createDockerTarArchive("test-image", configuration, jKubeBuildConfiguration, prefixedLogger, null, summaryService);
 
     // Then
     assertTargetHasDockerDirectories("test-image");

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/ArchiveService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/ArchiveService.java
@@ -18,6 +18,7 @@ import org.eclipse.jkube.kit.common.JKubeConfiguration;
 import org.eclipse.jkube.kit.build.api.assembly.ArchiverCustomizer;
 import org.eclipse.jkube.kit.build.api.assembly.AssemblyFiles;
 import org.eclipse.jkube.kit.build.api.assembly.AssemblyManager;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.common.KitLogger;
@@ -48,9 +49,9 @@ public class ArchiveService {
      * @return file for holding the sources
      * @throws IOException if during creation of the tar an error occurs.
      */
-    public File createDockerBuildArchive(ImageConfiguration imageConfig, JKubeConfiguration params)
+    public File createDockerBuildArchive(ImageConfiguration imageConfig, JKubeConfiguration params, SummaryService summaryService)
             throws IOException {
-        return createDockerBuildArchive(imageConfig, params, null);
+        return createDockerBuildArchive(imageConfig, params, null, summaryService);
     }
 
     /**
@@ -63,9 +64,9 @@ public class ArchiveService {
      * @return file for holding the sources
      * @throws IOException if during creation of the tar an error occurs.
      */
-    public File createDockerBuildArchive(ImageConfiguration imageConfig, JKubeConfiguration params, ArchiverCustomizer customizer)
+    public File createDockerBuildArchive(ImageConfiguration imageConfig, JKubeConfiguration params, ArchiverCustomizer customizer, SummaryService summaryService)
             throws IOException {
-        File ret = createArchive(imageConfig.getName(), imageConfig.getBuildConfiguration(), params, log, customizer);
+        File ret = createArchive(imageConfig.getName(), imageConfig.getBuildConfiguration(), params, log, customizer, summaryService);
         log.info("%s: Created docker source tar %s",imageConfig.getDescription(), ret);
         return ret;
     }
@@ -108,13 +109,14 @@ public class ArchiveService {
         return assemblyManager.createChangedFilesArchive(entries, assemblyDir, imageName, jKubeConfiguration);
     }
 
-    File createArchive(String imageName, BuildConfiguration buildConfig, JKubeConfiguration params, KitLogger log)
+    File createArchive(String imageName, BuildConfiguration buildConfig, JKubeConfiguration params, KitLogger log, SummaryService summaryService)
             throws IOException {
-        return createArchive(imageName, buildConfig, params, log, null);
+        return createArchive(imageName, buildConfig, params, log, null, summaryService);
     }
 
-    File createArchive(String imageName, BuildConfiguration buildConfig, JKubeConfiguration params, KitLogger log, ArchiverCustomizer customizer)
+    File createArchive(String imageName, BuildConfiguration buildConfig, JKubeConfiguration params, KitLogger log,
+                       ArchiverCustomizer customizer, SummaryService summaryService)
             throws IOException {
-        return assemblyManager.createDockerTarArchive(imageName, params, buildConfig, log, customizer);
+        return assemblyManager.createDockerTarArchive(imageName, params, buildConfig, log, customizer, summaryService);
     }
 }

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/BuildService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/BuildService.java
@@ -35,6 +35,7 @@ import org.eclipse.jkube.kit.build.service.docker.access.BuildOptions;
 import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
 import org.eclipse.jkube.kit.build.service.docker.access.DockerAccessException;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
@@ -146,6 +147,7 @@ public class BuildService {
             throw new IllegalStateException("Failure in building image, unable to find image built with name " + imageName);
         }
         log.info("%s: Built image %s", imageConfig.getDescription(), newImageId);
+        SummaryUtil.setImageShaImageSummary(imageName, newImageId);
 
         if (oldImageId != null && !oldImageId.equals(newImageId)) {
             try {
@@ -264,6 +266,7 @@ public class BuildService {
         }
         for (String fromImage : fromImages) {
             if (fromImage != null && !AssemblyManager.SCRATCH_IMAGE.equals(fromImage)) {
+                SummaryUtil.setBaseImageNameImageSummary(imageConfig.getName(), fromImage);
                 registryService.pullImageWithPolicy(fromImage, imagePullManager, configuration.getRegistryConfig(), buildConfig);
             }
         }

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/RegistryService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/RegistryService.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.kit.build.service.docker;
 
 import java.io.IOException;
+import java.util.Optional;
 
 import org.eclipse.jkube.kit.build.api.auth.AuthConfig;
 import org.eclipse.jkube.kit.build.service.docker.access.CreateImageOptions;
@@ -21,6 +22,7 @@ import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
 import org.eclipse.jkube.kit.build.service.docker.auth.AuthConfigFactory;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.EnvUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.common.RegistryConfig;
@@ -56,12 +58,14 @@ public class RegistryService {
         BuildConfiguration buildConfig = imageConfig.getBuildConfiguration();
         String name = imageConfig.getName();
         if (buildConfig != null) {
+            ImageName imageName = new ImageName(imageConfig.getName());
             String configuredRegistry = EnvUtil.firstRegistryOf(
-                new ImageName(imageConfig.getName()).getRegistry(),
+                imageName.getRegistry(),
                 imageConfig.getRegistry(),
                 registryConfig.getRegistry());
 
 
+            SummaryUtil.setPushRegistry(Optional.ofNullable(configuredRegistry).orElse("docker.io"));
             AuthConfig authConfig = createAuthConfig(true, new ImageName(name).getUser(), configuredRegistry, registryConfig);
 
             long start = System.currentTimeMillis();

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/RegistryService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/RegistryService.java
@@ -21,8 +21,8 @@ import org.eclipse.jkube.kit.build.service.docker.access.CreateImageOptions;
 import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
 import org.eclipse.jkube.kit.build.service.docker.auth.AuthConfigFactory;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.EnvUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.common.RegistryConfig;
@@ -54,7 +54,7 @@ public class RegistryService {
      * @throws IOException exception
      */
     public void pushImage(ImageConfiguration imageConfig,
-                          int retries, RegistryConfig registryConfig, boolean skipTag) throws IOException {
+                          int retries, RegistryConfig registryConfig, boolean skipTag, SummaryService summaryService) throws IOException {
         BuildConfiguration buildConfig = imageConfig.getBuildConfiguration();
         String name = imageConfig.getName();
         if (buildConfig != null) {
@@ -65,7 +65,7 @@ public class RegistryService {
                 registryConfig.getRegistry());
 
 
-            SummaryUtil.setPushRegistry(Optional.ofNullable(configuredRegistry).orElse("docker.io"));
+            summaryService.setPushRegistry(Optional.ofNullable(configuredRegistry).orElse("docker.io"));
             AuthConfig authConfig = createAuthConfig(true, new ImageName(name).getUser(), configuredRegistry, registryConfig);
 
             long start = System.currentTimeMillis();

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/BuildServiceTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/BuildServiceTest.java
@@ -17,6 +17,7 @@ import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
 import org.eclipse.jkube.kit.build.service.docker.access.DockerAccessException;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,7 @@ import static org.mockito.Mockito.when;
 class BuildServiceTest {
   private DockerAccess mockedDockerAccess;
   private BuildService buildService;
+  private SummaryService summaryService;
   private ImageConfiguration imageConfiguration;
   private ImagePullManager mockedImagePullManager;
   private JKubeConfiguration mockedJKubeConfiguration;
@@ -46,6 +48,7 @@ class BuildServiceTest {
     mockedDockerAccess = mock(DockerAccess.class, RETURNS_DEEP_STUBS);
     ArchiveService mockedArchiveService = mock(ArchiveService.class, RETURNS_DEEP_STUBS);
     RegistryService mockedRegistryService = mock(RegistryService.class, RETURNS_DEEP_STUBS);
+    summaryService = mock(SummaryService.class);
     KitLogger mockedLog = mock(KitLogger.SilentLogger.class, RETURNS_DEEP_STUBS);
     mockedImagePullManager = mock(ImagePullManager.class, RETURNS_DEEP_STUBS);
     mockedJKubeConfiguration = mock(JKubeConfiguration.class, RETURNS_DEEP_STUBS);
@@ -66,7 +69,7 @@ class BuildServiceTest {
     when(mockedDockerAccess.getImageId("image-name")).thenReturn("c8003cb6f5db");
 
     // When
-    buildService.buildImage(imageConfiguration, mockedImagePullManager, mockedJKubeConfiguration);
+    buildService.buildImage(imageConfiguration, mockedImagePullManager, mockedJKubeConfiguration, summaryService);
 
     // Then
     verify(mockedDockerAccess, times(1))
@@ -79,7 +82,7 @@ class BuildServiceTest {
     when(mockedDockerAccess.getImageId("image-name")).thenReturn(null);
     // When & Then
     assertThatIllegalStateException()
-            .isThrownBy(() -> buildService.buildImage(imageConfiguration, mockedImagePullManager, mockedJKubeConfiguration))
+            .isThrownBy(() -> buildService.buildImage(imageConfiguration, mockedImagePullManager, mockedJKubeConfiguration, summaryService))
             .withMessage("Failure in building image, unable to find image built with name image-name");
   }
 

--- a/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/RegistryServiceTest.java
+++ b/jkube-kit/build/service/docker/src/test/java/org/eclipse/jkube/kit/build/service/docker/RegistryServiceTest.java
@@ -17,6 +17,7 @@ import org.eclipse.jkube.kit.build.service.docker.access.CreateImageOptions;
 import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.RegistryConfig;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +46,7 @@ class RegistryServiceTest {
   private RegistryService registryService;
   private ImageConfiguration imageConfiguration;
   private RegistryConfig mockedRegistryConfig;
+  private SummaryService summaryService;
 
   @BeforeEach
   void setUp() {
@@ -58,6 +60,7 @@ class RegistryServiceTest {
     dockerAccess = mock(DockerAccess.class);
     queryService = mock(QueryService.class);
     mockedRegistryConfig = mock(RegistryConfig.class);
+    summaryService = mock(SummaryService.class);
     registryService = new RegistryService(dockerAccess, queryService, new KitLogger.SilentLogger());
     when(mockedRegistryConfig.getRegistry()).thenReturn("example.com");
   }
@@ -117,7 +120,7 @@ class RegistryServiceTest {
   @Test
   void pushImage_whenValidImageConfigurationProvidedWithSkipTag_shouldNotPushAdditionalTags() throws IOException {
     // When
-    registryService.pushImage(imageConfiguration, 1, mockedRegistryConfig, true);
+    registryService.pushImage(imageConfiguration, 1, mockedRegistryConfig, true, summaryService);
 
     // Then
     verify(dockerAccess, times(1))
@@ -129,7 +132,7 @@ class RegistryServiceTest {
   @Test
   void pushImage_whenValidImageConfigurationProvided_shouldPushApplicableTags() throws IOException {
     // When
-    registryService.pushImage(imageConfiguration, 1, mockedRegistryConfig, false);
+    registryService.pushImage(imageConfiguration, 1, mockedRegistryConfig, false, summaryService);
 
     // Then
     verify(dockerAccess, times(1))

--- a/jkube-kit/build/service/jib/src/main/java/org/eclipse/jkube/kit/service/jib/JibServiceUtil.java
+++ b/jkube-kit/build/service/jib/src/main/java/org/eclipse/jkube/kit/service/jib/JibServiceUtil.java
@@ -35,6 +35,7 @@ import org.eclipse.jkube.kit.build.api.assembly.BuildDirs;
 import org.eclipse.jkube.kit.common.Assembly;
 import org.eclipse.jkube.kit.common.AssemblyFileEntry;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.common.Arguments;
@@ -117,6 +118,7 @@ public class JibServiceUtil {
 
     public static JibContainerBuilder containerFromImageConfiguration(
         ImageConfiguration imageConfiguration, Credential pullRegistryCredential) throws InvalidImageReferenceException {
+        SummaryUtil.setBaseImageNameImageSummary(imageConfiguration.getName(), imageConfiguration.getBuildConfiguration().getFrom());
         final JibContainerBuilder containerBuilder = Jib.from(getRegistryImage(getBaseImage(imageConfiguration), pullRegistryCredential))
                 .setFormat(ImageFormat.Docker);
         return populateContainerBuilderFromImageConfiguration(containerBuilder, imageConfiguration);
@@ -129,6 +131,8 @@ public class JibServiceUtil {
         } else {
             imageName = new ImageName(imageConfiguration.getName());
         }
+        SummaryUtil.setPushRegistry(Optional.ofNullable(imageName.getRegistry())
+            .orElse("docker.io"));
         return imageName.getFullName();
     }
 

--- a/jkube-kit/build/service/jib/src/test/java/org/eclipse/jkube/kit/service/jib/JibServiceUtilTest.java
+++ b/jkube-kit/build/service/jib/src/test/java/org/eclipse/jkube/kit/service/jib/JibServiceUtilTest.java
@@ -30,6 +30,8 @@ import org.eclipse.jkube.kit.common.AssemblyFile;
 import org.eclipse.jkube.kit.common.AssemblyFileEntry;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.Arguments;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
@@ -39,6 +41,7 @@ import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
 import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
 import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
 import com.google.cloud.tools.jib.api.buildplan.Port;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.MockedConstruction;
@@ -51,6 +54,12 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 class JibServiceUtilTest {
+    private SummaryService summaryService;
+
+    @BeforeEach
+    public void setUp() {
+        summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
+    }
 
     @Test
     void testGetBaseImageWithNullBuildConfig() {
@@ -77,7 +86,7 @@ class JibServiceUtilTest {
             // Given
             ImageConfiguration imageConfiguration = getSampleImageConfiguration();
             // When
-            JibContainerBuilder jibContainerBuilder = containerFromImageConfiguration(imageConfiguration, null);
+            JibContainerBuilder jibContainerBuilder = containerFromImageConfiguration(imageConfiguration, null, summaryService);
             // Then
             verify(jibContainerBuilder, times(1)).addLabel("foo", "bar");
             verify(jibContainerBuilder, times(1)).setEntrypoint(Arrays.asList("java", "-jar", "foo.jar"));
@@ -105,13 +114,13 @@ class JibServiceUtilTest {
 
     @Test
     void testGetFullImageNameWithDefaultTag() {
-        assertThat(JibServiceUtil.getFullImageName(getSampleImageConfiguration(), null))
+        assertThat(JibServiceUtil.getFullImageName(getSampleImageConfiguration(), null, summaryService))
             .isEqualTo("test/test-project:latest");
     }
 
     @Test
     void testGetFullImageNameWithProvidedTag() {
-        assertThat(JibServiceUtil.getFullImageName(getSampleImageConfiguration(), "0.0.1"))
+        assertThat(JibServiceUtil.getFullImageName(getSampleImageConfiguration(), "0.0.1", summaryService))
             .isEqualTo("test/test-project:0.0.1");
     }
 

--- a/jkube-kit/common-maven/src/main/java/org/eclipse/jkube/kit/common/util/MavenUtil.java
+++ b/jkube-kit/common-maven/src/main/java/org/eclipse/jkube/kit/common/util/MavenUtil.java
@@ -272,6 +272,13 @@ public class MavenUtil {
         return answer;
     }
 
+    public static String getLastExecutingGoal(MavenSession session, String logPrefix) {
+        List<String> goals = session.getGoals().stream()
+            .filter(g -> g.startsWith(logPrefix))
+            .collect(Collectors.toList());
+        return goals.isEmpty() ? null : goals.get(goals.size() - 1).substring(logPrefix.length());
+    }
+
     private static File getArtifactFileFromArtifactMap(MavenProject mavenProject, org.apache.maven.model.Dependency dependency) {
         Artifact artifact = mavenProject.getArtifactMap().get(dependency.getGroupId() + ":" + dependency.getArtifactId());
         if (artifact != null) {

--- a/jkube-kit/common-maven/src/test/java/org/eclipse/jkube/kit/common/util/MavenUtilTest.java
+++ b/jkube-kit/common-maven/src/test/java/org/eclipse/jkube/kit/common/util/MavenUtilTest.java
@@ -158,6 +158,32 @@ class MavenUtilTest {
     assertThat(plugins.get(1).getExecutions()).isEqualTo(Arrays.asList("resource", "build", "helm"));
   }
 
+  @Test
+  void getLastExecutingGoal_whenSessionReturnsGoalsList_thenLastExecutingGoalReturned() {
+    // Given
+    MavenSession mavenSession = mock(MavenSession.class);
+    when(mavenSession.getGoals()).thenReturn(Arrays.asList("clean", "k8s:build", "k8s:resource"));
+
+    // When
+    String lastExecutingGoal = MavenUtil.getLastExecutingGoal(mavenSession, "k8s:");
+
+    // Then
+    assertThat(lastExecutingGoal).isEqualTo("resource");
+  }
+
+  @Test
+  void getLastExecutingGoal_whenSessionReturnsEmptyList_thenNullReturned() {
+    // Given
+    MavenSession mavenSession = mock(MavenSession.class);
+    when(mavenSession.getGoals()).thenReturn(Collections.emptyList());
+
+    // When
+    String lastExecutingGoal = MavenUtil.getLastExecutingGoal(mavenSession, "k8s:");
+
+    // Then
+    assertThat(lastExecutingGoal).isNull();
+  }
+
   private MavenProject getMavenProject() {
     mavenProject = new MavenProject();
     File baseDir = new File("test-project-base-dir");

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/JKubeConfiguration.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/JKubeConfiguration.java
@@ -52,6 +52,10 @@ public class JKubeConfiguration implements Serializable {
     return project.getProperties();
   }
 
+  public File getBuildDirectory() {
+    return project.getBuildDirectory();
+  }
+
   public File inOutputDir(String path) {
     return inDir(getOutputDirectory(), path);
   }

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/summary/ImageSummary.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/summary/ImageSummary.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.summary;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+public class ImageSummary {
+  private String baseImageName;
+  private String dockerfilePath;
+  private String imageStreamUsed;
+  private String imageSha;
+
+  public ImageSummary(String baseImageName, String dockerfilePath, String imageStreamUsed, String imageSha) {
+    this.baseImageName = baseImageName;
+    this.dockerfilePath = dockerfilePath;
+    this.imageStreamUsed = imageStreamUsed;
+    this.imageSha = imageSha;
+  }
+}

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/summary/KubernetesResourceSummary.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/summary/KubernetesResourceSummary.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.summary;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+public class KubernetesResourceSummary {
+  private String resourceName;
+  private String group;
+  private String version;
+  private String kind;
+  private String namespace;
+
+  public KubernetesResourceSummary(String resourceName, String group, String version, String kind, String namespace) {
+    this.resourceName = resourceName;
+    this.group = group;
+    this.version = version;
+    this.kind = kind;
+    this.namespace = namespace;
+  }
+}

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/summary/Summary.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/summary/Summary.java
@@ -26,6 +26,8 @@ public class Summary {
   private Map<String, ImageSummary> imageSummariesMap;
   private String buildStrategy;
   private List<String> generatorsApplied;
+  private String actionType;
+  private List<String> actionsRun;
   private String openShiftBuildConfigName;
   private boolean successful;
   private String failureCause;

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/summary/Summary.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/summary/Summary.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.summary;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@Setter
+public class Summary {
+  private Map<String, ImageSummary> imageSummariesMap;
+  private String buildStrategy;
+  private List<String> generatorsApplied;
+  private String openShiftBuildConfigName;
+  private boolean successful;
+  private String failureCause;
+  private File aggregateResourceFile;
+  private String appliedClusterUrl;
+  private String undeployedClusterUrl;
+  private String pushRegistry;
+  private String helmChartName;
+  private File helmChartCompressed;
+  private File helmChart;
+  private String helmRepository;
+  private List<File> generatedResourceFiles;
+  private List<KubernetesResourceSummary> appliedKubernetesResources;
+  private List<KubernetesResourceSummary> deletedKubernetesResources;
+  private List<String> enrichersApplied;
+}

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/SummaryUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/SummaryUtil.java
@@ -1,0 +1,449 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util;
+
+import io.fabric8.kubernetes.client.utils.Serialization;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.summary.ImageSummary;
+import org.eclipse.jkube.kit.common.summary.KubernetesResourceSummary;
+import org.eclipse.jkube.kit.common.summary.Summary;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+
+import static org.eclipse.jkube.kit.common.util.FileUtil.createDirectory;
+
+public class SummaryUtil {
+  private static final String SUMMARY_FILE_NAME = "summary.json";
+  private static final String DASHED_LINE = "-------------------------------";
+  private static final String LIST_ELEMENT = " - %s";
+  private static File summaryFile = null;
+  private static File summaryOutputDir = null;
+  private static KitLogger logger = null;
+
+  private SummaryUtil() { }
+
+  public static void initSummary(File summaryOutputDirectory, KitLogger kitLogger) {
+    summaryOutputDir = summaryOutputDirectory;
+    logger = kitLogger;
+  }
+
+  public static void addGeneratedResourceFile(File resourceFilePath) {
+    addToSummary(s -> {
+      s.setGeneratedResourceFiles(createOrAddToExistingList(s.getGeneratedResourceFiles(), resourceFilePath));
+      return s;
+    });
+  }
+
+  public static void addAppliedKubernetesResource(KubernetesResourceSummary kubernetesResource) {
+    addToSummary(s -> {
+      s.setAppliedKubernetesResources(createOrAddToExistingList(s.getAppliedKubernetesResources(), kubernetesResource));
+      return s;
+    });
+  }
+
+  public static void addDeletedKubernetesResource(KubernetesResourceSummary kubernetesResource) {
+    addToSummary(s -> {
+      s.setDeletedKubernetesResources(createOrAddToExistingList(s.getDeletedKubernetesResources(), kubernetesResource));
+      return s;
+    });
+  }
+
+  public static void addToGenerators(String generator) {
+    addToSummary(s -> {
+      s.setGeneratorsApplied(createOrAddToExistingList(s.getGeneratorsApplied(), generator));
+      return s;
+    });
+  }
+
+  public static void addToEnrichers(String enricher) {
+    addToSummary(s -> {
+      s.setEnrichersApplied(createOrAddToExistingList(s.getEnrichersApplied(), enricher));
+      return s;
+    });
+  }
+
+  public static void setSuccessful(boolean isSuccessful) {
+    addToSummary(s -> {
+      s.setSuccessful(isSuccessful);
+      return s;
+    });
+  }
+
+  public static void setFailureCause(String failureCause) {
+    addToSummary(s -> {
+      s.setFailureCause(failureCause);
+      return s;
+    });
+  }
+
+  public static void setDockerFileImageSummary(String imageName, String dockerFileLocation) {
+    addToSummary(s -> {
+      s.setImageSummariesMap(createOrAddToExistingMap(s.getImageSummariesMap(), imageName, () -> ImageSummary.builder().build(), is -> {
+        is.setDockerfilePath(dockerFileLocation);
+        return is;
+      }));
+      return s;
+    });
+  }
+
+  public static void setImageShaImageSummary(String imageName, String imageSha) {
+    addToSummary(s -> {
+      s.setImageSummariesMap(createOrAddToExistingMap(s.getImageSummariesMap(), imageName, () -> ImageSummary.builder().build(), is -> {
+        is.setImageSha(imageSha);
+        return is;
+      }));
+      return s;
+    });
+  }
+
+  public static void setImageStreamUsedImageSummary(String imageName, String imageStreamUsed) {
+    addToSummary(s -> {
+      s.setImageSummariesMap(createOrAddToExistingMap(s.getImageSummariesMap(), imageName, () -> ImageSummary.builder().build(), is -> {
+        is.setImageStreamUsed(imageStreamUsed);
+        return is;
+      }));
+      return s;
+    });
+  }
+
+  public static void setBaseImageNameImageSummary(String imageName, String baseImage) {
+    addToSummary(s -> {
+      s.setImageSummariesMap(createOrAddToExistingMap(s.getImageSummariesMap(), imageName, () -> ImageSummary.builder().build(), is -> {
+        is.setBaseImageName(baseImage);
+        return is;
+      }));
+      return s;
+    });
+  }
+
+  public static void setPushRegistry(String registry) {
+    addToSummary(s -> {
+      s.setPushRegistry(registry);
+      return s;
+    });
+  }
+
+  public static void setBuildStrategy(String buildStrategy) {
+    addToSummary(s -> {
+      s.setBuildStrategy(buildStrategy);
+      return s;
+    });
+  }
+
+  public static void setAppliedClusterUrl(String targetClusterUrl) {
+    addToSummary(s -> {
+      s.setAppliedClusterUrl(targetClusterUrl);
+      return s;
+    });
+  }
+
+  public static void setUndeployedClusterUrl(String targetClusterUrl) {
+    addToSummary(s -> {
+      s.setUndeployedClusterUrl(targetClusterUrl);
+      return s;
+    });
+  }
+
+  public static void setOpenShiftBuildConfigName(String buildConfigName) {
+    addToSummary(s -> {
+      s.setOpenShiftBuildConfigName(buildConfigName);
+      return s;
+    });
+  }
+
+  public static void setHelmChartName(String chart) {
+    addToSummary(s -> {
+      s.setHelmChartName(chart);
+      return s;
+    });
+  }
+
+  public static void setHelmChartLocation(File chart) {
+    addToSummary(s -> {
+      s.setHelmChart(chart);
+      return s;
+    });
+  }
+
+  public static void setHelmRepository(String helmRepository) {
+    addToSummary(s -> {
+      s.setHelmRepository(helmRepository);
+      return s;
+    });
+  }
+
+  public static void setHelmChartCompressedLocation(File chartCompressed) {
+    addToSummary(s -> {
+      s.setHelmChartCompressed(chartCompressed);
+      return s;
+    });
+  }
+
+  public static void setAggregateResourceFile(File aggregateResourceFile) {
+    addToSummary(s -> {
+      s.setAggregateResourceFile(aggregateResourceFile);
+      return s;
+    });
+  }
+
+  public static void clear() {
+    if (summaryFile != null && summaryFile.exists()) {
+      try {
+        Files.delete(summaryFile.toPath());
+        summaryFile = null;
+      } catch (IOException e) {
+        throw new IllegalStateException("Unable to delete summary file", e);
+      }
+    }
+  }
+
+  public static <T extends Exception> void setFailureIfSummaryEnabledOrThrow(boolean summaryEnabled, String failureMessage, Supplier<T> exceptionSupplier) throws T {
+    if (summaryEnabled) {
+      setSuccessful(false);
+      setFailureCause(failureMessage);
+    } else {
+      throw exceptionSupplier.get();
+    }
+  }
+
+  public static void printSummary(File baseDirectory, boolean summaryEnabled) {
+    Summary summaryInstance = loadSummaryFromFile();
+    if (summaryInstance != null && summaryEnabled) {
+      printBanner(logger);
+      printCommonSummary(summaryInstance, baseDirectory, logger);
+      printBuildSummary(summaryInstance, logger);
+      printPushSummary(summaryInstance, logger);
+      printResourceSummary(summaryInstance, baseDirectory, logger);
+      printApplySummary(summaryInstance, logger);
+      printUndeploySummary(summaryInstance, logger);
+      printHelmSummary(summaryInstance, baseDirectory, logger);
+      printHelmPushSummary(summaryInstance, logger);
+      logger.info(DASHED_LINE);
+      if (summaryInstance.isSuccessful()) {
+        logger.info("SUCCESS");
+      } else {
+        logger.error("FAILURE [%s]", summaryInstance.getFailureCause());
+      }
+      logger.info(DASHED_LINE);
+    }
+  }
+
+  private static void printCommonSummary(Summary summaryInstance, File baseDirectory, KitLogger logger) {
+    if (summaryInstance.getImageSummariesMap() != null && !summaryInstance.getImageSummariesMap().isEmpty()) {
+      logger.info("Container images:");
+      for (Map.Entry<String, ImageSummary> imageSummaryEntry : summaryInstance.getImageSummariesMap().entrySet()) {
+        printImageSummary(logger, baseDirectory, imageSummaryEntry.getKey(), imageSummaryEntry.getValue());
+      }
+      logger.info("");
+    }
+  }
+
+  private static void printImageSummary(KitLogger logger, File baseDirectory, String imageName, ImageSummary imageSummary) {
+    logger.info(LIST_ELEMENT, imageName);
+    if (imageSummary.getBaseImageName() != null) {
+      logger.info("    * Base image: %s", imageSummary.getBaseImageName());
+    }
+    if (imageSummary.getDockerfilePath() != null) {
+      logger.info("    * Dockerfile image: %s", FileUtil.getRelativeFilePath(baseDirectory.getAbsolutePath(), imageSummary.getDockerfilePath()));
+    }
+    if (imageSummary.getImageStreamUsed() != null) {
+      logger.info("    * ImageStream: %s", imageSummary.getImageStreamUsed());
+    }
+    if (imageSummary.getImageSha() != null) {
+      logger.info("    * SHA: %s", imageSummary.getImageSha());
+    }
+  }
+
+  private static void printBanner(KitLogger logger) {
+    logger.info(" __ / / //_/ / / / _ )/ __/");
+    logger.info("/ // / ,< / /_/ / _  / _/  ");
+    logger.info("\\___/_/|_|\\____/____/___/  \n");
+    logger.info(DASHED_LINE);
+    logger.info("      SUMMARY");
+    logger.info(DASHED_LINE);
+  }
+
+  private static void printBuildSummary(Summary summary, KitLogger logger) {
+    if (summary.getBuildStrategy() != null) {
+      logger.info("Build Strategy : %s", summary.getBuildStrategy());
+    }
+    if (summary.getGeneratorsApplied() != null && !summary.getGeneratorsApplied().isEmpty()) {
+      logger.info("Generators applied: [%s]",  String.join(",", summary.getGeneratorsApplied()));
+    }
+    if (summary.getOpenShiftBuildConfigName() != null) {
+      logger.info("Build config: %s", summary.getOpenShiftBuildConfigName());
+    }
+    logger.info("");
+  }
+
+  private static void printResourceSummary(Summary summary, File baseDir, KitLogger logger) {
+    if (summary.getGeneratedResourceFiles() != null && !summary.getGeneratedResourceFiles().isEmpty()) {
+      if (summary.getEnrichersApplied() != null && summary.getEnrichersApplied().size() < 20) {
+        logger.info("Enrichers applied: [%s]", String.join(",", summary.getEnrichersApplied()));
+      }
+      logger.info("Generated resources:");
+      List<String> generatedFilesResourcePaths = summary.getGeneratedResourceFiles().stream()
+          .map(File::getAbsolutePath)
+          .map(p -> FileUtil.getRelativeFilePath(baseDir.getAbsolutePath(), p))
+          .collect(Collectors.toList());
+      logList(logger, generatedFilesResourcePaths);
+    }
+    if (summary.getAggregateResourceFile() != null) {
+      logger.info(LIST_ELEMENT, FileUtil.getRelativeFilePath(baseDir.getAbsolutePath(), summary.getAggregateResourceFile().getAbsolutePath()));
+    }
+    logger.info("");
+  }
+
+  private static void printApplySummary(Summary summary, KitLogger logger) {
+    if (StringUtils.isNotBlank(summary.getAppliedClusterUrl())) {
+      logger.info("Applied resources from %s", summary.getAppliedClusterUrl());
+      printKubernetesResourceSummary(summary.getAppliedKubernetesResources(), logger);
+      logger.info("");
+    }
+  }
+
+  private static void printUndeploySummary(Summary summary, KitLogger logger) {
+    if (StringUtils.isNotBlank(summary.getUndeployedClusterUrl())) {
+      logger.info("Undeployed resources from %s", summary.getUndeployedClusterUrl());
+      printKubernetesResourceSummary(summary.getDeletedKubernetesResources(), logger);
+      logger.info("");
+    }
+  }
+
+  private static void printKubernetesResourceSummary(List<KubernetesResourceSummary> kubernetesResourceSummaries, KitLogger logger) {
+    if (kubernetesResourceSummaries != null && !kubernetesResourceSummaries.isEmpty()) {
+      for (KubernetesResourceSummary kubernetesResourceSummary : kubernetesResourceSummaries) {
+        logger.info(LIST_ELEMENT, kubernetesResourceSummary.getResourceName());
+        if (kubernetesResourceSummary.getGroup().equals(kubernetesResourceSummary.getVersion())) {
+          logger.info("   * %s %s", kubernetesResourceSummary.getGroup(), kubernetesResourceSummary.getKind());
+        } else {
+          logger.info("   * %s/%s %s", kubernetesResourceSummary.getGroup(), kubernetesResourceSummary.getVersion(), kubernetesResourceSummary.getKind());
+        }
+        logger.info("   * Namespace: %s", kubernetesResourceSummary.getNamespace());
+      }
+    }
+  }
+
+  private static void printPushSummary(Summary summary, KitLogger logger) {
+    if (StringUtils.isNotBlank(summary.getPushRegistry())) {
+      logger.info("Registry: %s", summary.getPushRegistry());
+    }
+  }
+
+  private static void printHelmSummary(Summary summary, File baseDir, KitLogger logger) {
+    if (StringUtils.isNotBlank(summary.getHelmChartName())) {
+      logger.info("Chart : %s", summary.getHelmChartName());
+    }
+    if (summary.getHelmChart() != null) {
+      logger.info("Location : %s", FileUtil.getRelativeFilePath(baseDir.getAbsolutePath(), summary.getHelmChart().getAbsolutePath()));
+    }
+    if (summary.getHelmChartCompressed() != null) {
+      logger.info("Compressed : %s", FileUtil.getRelativeFilePath(baseDir.getAbsolutePath(), summary.getHelmChartCompressed().getAbsolutePath()));
+    }
+  }
+
+  private static void printHelmPushSummary(Summary summary, KitLogger logger) {
+    if (StringUtils.isNotBlank(summary.getHelmRepository())) {
+      logger.info("Repository : %s", summary.getHelmRepository());
+    }
+  }
+
+  private static void logList(KitLogger logger, List<String> list) {
+    for (String item : list) {
+      logger.info(LIST_ELEMENT, item);
+    }
+  }
+
+  private static void addToSummary(UnaryOperator<Summary> summaryConsumer) {
+    if (summaryOutputDir != null && summaryOutputDir.exists()) {
+      Summary summary = loadSummaryFromFile();
+      if (summary == null) {
+        summary = new Summary();
+      }
+      summary = summaryConsumer.apply(summary);
+      writeSummaryToFile(summary);
+    }
+  }
+
+  private static <K, V> Map<K, V> createOrAddToExistingMap(Map<K, V> orignalMap, K key,  Supplier<V> emptySupplier, UnaryOperator<V> valueConsumer) {
+    if (orignalMap == null) {
+      orignalMap = new HashMap<>();
+    }
+    orignalMap.computeIfAbsent(key, s -> emptySupplier.get());
+    orignalMap.put(key, valueConsumer.apply(orignalMap.get(key)));
+    return orignalMap;
+  }
+
+  private static <T> List<T> createOrAddToExistingList(List<T> currentList, T item) {
+    if (currentList == null) {
+      currentList = new ArrayList<>();
+    }
+    if (!currentList.contains(item)) {
+      currentList.add(item);
+    }
+    return currentList;
+  }
+
+  private static synchronized Summary loadSummaryFromFile() {
+    try {
+      if (!isValidSummaryFile(summaryFile)) {
+        summaryFile = createSummaryFile();
+        summaryFile.deleteOnExit();
+        return null;
+      }
+      return Serialization.jsonMapper().readValue(summaryFile, Summary.class);
+    } catch (IOException ioException) {
+      throw new IllegalStateException("Failure in loading Summary file: ", ioException);
+    }
+  }
+
+  private static File createSummaryFile() throws IOException {
+    if (!summaryOutputDir.exists()) {
+      createDirectory(summaryOutputDir);
+    }
+    File summaryFile = new File(summaryOutputDir, SUMMARY_FILE_NAME);
+    if (summaryFile.createNewFile()) {
+      logger.verbose("Created summary file");
+    }
+    return summaryFile;
+  }
+
+  private static void writeSummaryToFile(Summary summary) {
+    if (isValidSummaryFile(summaryFile)) {
+      try (FileWriter fileWriter = new FileWriter(summaryFile)) {
+        fileWriter.write(Serialization.jsonMapper().writeValueAsString(summary));
+      } catch (IOException ioException) {
+        throw new IllegalStateException("Failure in writing to Summary file: ", ioException);
+      }
+    }
+  }
+
+  private static boolean isValidSummaryFile(File summaryFile) {
+    return summaryFile != null &&
+        StringUtils.isNotBlank(summaryFile.getAbsolutePath()) &&
+        summaryFile.getAbsolutePath().contains(SUMMARY_FILE_NAME) &&
+        summaryFile.exists();
+  }
+}

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/JKubeConfigurationTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/JKubeConfigurationTest.java
@@ -40,6 +40,17 @@ class JKubeConfigurationTest {
   }
 
   @Test
+  void getBuildDirectory_withJavaProject_shouldReturnJavaProjectBuildDirectory() {
+    // Given
+    final JKubeConfiguration configuration = JKubeConfiguration.builder().project(JavaProject.builder()
+        .buildDirectory(new File("build-directory")).build()).build();
+    // When
+    final File result = configuration.getBuildDirectory();
+    // Then
+    assertThat(result).isEqualTo(new File("build-directory"));
+  }
+
+  @Test
   void getProperties_withJavaProject_shouldReturnJavaProjectProperties() {
     // Given
     final Properties props = new Properties();

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/SummaryUtilTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/SummaryUtilTest.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common;
+
+import org.eclipse.jkube.kit.common.summary.KubernetesResourceSummary;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.File;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class SummaryUtilTest {
+  private KitLogger logger;
+  @TempDir
+  private File temporaryFolder;
+
+  @BeforeEach
+  public void setUp() {
+    logger = spy(new KitLogger.SilentLogger());
+    SummaryUtil.initSummary(temporaryFolder, logger);
+  }
+
+  @Test
+  void printSummary_whenInvoked_shouldPrintSummary() {
+    // Given
+    initializeSummary();
+
+    // When
+    SummaryUtil.printSummary(temporaryFolder, true);
+
+    // Then
+    verifySummaryPrintedOnce();
+  }
+
+  @Test
+  void printSummary_whenFailure_shouldPrintFailureAndCause() {
+    // Given
+    SummaryUtil.setSuccessful(false);
+    SummaryUtil.setFailureCause("failure in pulling image");
+
+    // When
+    SummaryUtil.printSummary(temporaryFolder, true);
+
+    // Then
+    verify(logger).error("FAILURE [%s]", "failure in pulling image");
+  }
+
+  @Test
+  void printSummary_whenSummaryEnabledFalse_shouldNotPrintAnything() {
+    // Given + When
+    SummaryUtil.printSummary(temporaryFolder, false);
+
+    // Then
+    verify(logger, times(0)).info(anyString());
+  }
+
+  @Test
+  void setFailureIfSummaryEnabledOrThrow_whenSummaryEnabled_shouldLogFailureAndCause() {
+    // Given
+    SummaryUtil.setFailureIfSummaryEnabledOrThrow(true, "failed to execute", () -> new IllegalStateException("failure"));
+
+    // When
+    SummaryUtil.printSummary(temporaryFolder, true);
+
+    // Then
+    verify(logger).error("FAILURE [%s]", "failed to execute");
+  }
+
+  @Test
+  void setFailureIfSummaryEnabledOrThrow_whenSummaryDisabled_shouldLogThrowException() {
+    // When + Then
+    assertThatIllegalStateException()
+        .isThrownBy(() -> SummaryUtil.setFailureIfSummaryEnabledOrThrow(false, "failed", () -> new IllegalStateException("failure")))
+        .withMessage("failure");
+    verify(logger, times(0)).error(anyString(), anyString());
+  }
+
+  @Test
+  void clear_whenInvoked_shouldDeleteSummaryFile() {
+    // Given
+    SummaryUtil.setSuccessful(true);
+
+    // When
+    SummaryUtil.clear();
+
+    // Then
+    verify(logger, times(0)).info(anyString());
+  }
+
+  private void initializeSummary() {
+    SummaryUtil.setBuildStrategy("Local Docker");
+    SummaryUtil.addToGenerators("java-exec");
+    SummaryUtil.setDockerFileImageSummary("quay.io/example/test:latest", new File(temporaryFolder, "src/main/docker/Dockerfile").getAbsolutePath());
+    SummaryUtil.setBaseImageNameImageSummary("quay.io/example/test:latest", "quay.io/jkube/java:latest");
+    SummaryUtil.setImageShaImageSummary("quay.io/example/test:latest", "def3");
+    SummaryUtil.setImageStreamUsedImageSummary("quay.io/example/test:latest", "test");
+    SummaryUtil.setPushRegistry("quay.io");
+    SummaryUtil.setOpenShiftBuildConfigName("test");
+    SummaryUtil.addGeneratedResourceFile(new File(temporaryFolder, "target/classes/META-INF/jkube/kubernetes/test-deployment.yml"));
+    SummaryUtil.addGeneratedResourceFile(new File(temporaryFolder, "target/classes/META-INF/jkube/kubernetes/test-service.yml"));
+    SummaryUtil.setAggregateResourceFile(new File(temporaryFolder, "target/classes/META-INF/jkube/kubernetes.yml"));
+    SummaryUtil.addToEnrichers("jkube-controller");
+    SummaryUtil.addToEnrichers("jkube-service");
+    SummaryUtil.addAppliedKubernetesResource(KubernetesResourceSummary.builder()
+        .kind("Deployment")
+        .group("apps")
+        .version("v1")
+        .namespace("test-ns")
+        .resourceName("test")
+        .build());
+    SummaryUtil.addAppliedKubernetesResource(KubernetesResourceSummary.builder()
+        .kind("Service")
+        .group("v1")
+        .version("v1")
+        .namespace("test-ns")
+        .resourceName("test")
+        .build());
+    SummaryUtil.setHelmChartName("test");
+    SummaryUtil.setHelmChartCompressedLocation(new File(temporaryFolder, "target/test.tar.gz"));
+    SummaryUtil.setHelmChartLocation(new File(temporaryFolder, "target/jkube/helm/test/kubernetes"));
+    SummaryUtil.setHelmRepository("localhost:8001/api/charts");
+    SummaryUtil.addDeletedKubernetesResource(KubernetesResourceSummary.builder()
+        .kind("Deployment")
+        .group("apps")
+        .version("v1")
+        .namespace("test-ns")
+        .resourceName("test")
+        .build());
+    SummaryUtil.addDeletedKubernetesResource(KubernetesResourceSummary.builder()
+        .kind("Service")
+        .group("v1")
+        .version("v1")
+        .namespace("test-ns")
+        .resourceName("test")
+        .build());
+    SummaryUtil.setAppliedClusterUrl("https://192.168.39.75:8443/");
+    SummaryUtil.setUndeployedClusterUrl("https://192.168.39.75:8443/");
+    SummaryUtil.setSuccessful(true);
+  }
+
+  private void verifySummaryPrintedOnce() {
+    verifySummaryBannerPrinted();
+    verifyCommonSummaryPrinted();
+    verifyBuildSummaryPrinted();
+    verifyPushSummaryPrinted();
+    verifyResourceSummaryPrinted();
+    verifyHelmSummaryPrinted();
+    verifyApplyUndeploySummaryPrinted();
+    verify(logger).info("      SUMMARY");
+  }
+
+  private void verifyApplyUndeploySummaryPrinted() {
+    verify(logger).info("Undeployed resources from %s", "https://192.168.39.75:8443/");
+    verify(logger, times(4)).info(" - %s", "test");
+    verify(logger, times(2)).info("   * %s/%s %s", "apps", "v1", "Deployment");
+    verify(logger, times(4)).info("   * Namespace: %s", "test-ns");
+    verify(logger, times(2)).info("   * %s %s", "v1", "Service");
+  }
+
+  private void verifyPushSummaryPrinted() {
+    verify(logger).info("Registry: %s", "quay.io");
+  }
+
+  private void verifyBuildSummaryPrinted() {
+    verify(logger).info("Build Strategy : %s", "Local Docker");
+    verify(logger).info("Generators applied: [%s]", "java-exec");
+    verify(logger).info("Build config: %s", "test");
+  }
+
+  private void verifyCommonSummaryPrinted() {
+    verify(logger).info("Container images:");
+    verify(logger).info(" - %s", "quay.io/example/test:latest");
+    verify(logger).info("    * Base image: %s", "quay.io/jkube/java:latest");
+    verify(logger).info("    * Dockerfile image: %s", "src/main/docker/Dockerfile");
+    verify(logger).info("    * SHA: %s", "def3");
+    verify(logger).info("    * ImageStream: %s", "test");
+  }
+
+  private void verifySummaryBannerPrinted() {
+    verify(logger, times(4)).info("-------------------------------");
+    verify(logger).info("      SUMMARY");
+    verify(logger).info(" __ / / //_/ / / / _ )/ __/");
+    verify(logger).info("/ // / ,< / /_/ / _  / _/  ");
+    verify(logger).info("\\___/_/|_|\\____/____/___/  \n");
+  }
+
+  private void verifyResourceSummaryPrinted() {
+    verify(logger).info("Enrichers applied: [%s]", "jkube-controller,jkube-service");
+    verify(logger).info("Generated resources:");
+    verify(logger).info(" - %s", "target/classes/META-INF/jkube/kubernetes/test-deployment.yml");
+    verify(logger).info(" - %s", "target/classes/META-INF/jkube/kubernetes/test-service.yml");
+    verify(logger).info(" - %s", "target/classes/META-INF/jkube/kubernetes.yml");
+  }
+
+  private void verifyHelmSummaryPrinted() {
+    verify(logger).info("Chart : %s", "test");
+    verify(logger).info("Location : %s", "target/jkube/helm/test/kubernetes");
+    verify(logger).info("Compressed : %s", "target/test.tar.gz");
+  }
+}

--- a/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceService.java
+++ b/jkube-kit/config/resource/src/main/java/org/eclipse/jkube/kit/config/resource/ResourceService.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.ResourceClassifier;
 
 import io.fabric8.kubernetes.api.model.KubernetesList;
@@ -26,7 +27,7 @@ public interface ResourceService {
   KubernetesList generateResources(PlatformMode platformMode, EnricherManager enricherManager, KitLogger log)
       throws IOException;
 
-  File writeResources(KubernetesList resources, ResourceClassifier classifier, KitLogger log) throws IOException;
+  File writeResources(KubernetesList resources, ResourceClassifier classifier, KitLogger log, SummaryService summaryService) throws IOException;
 
   @FunctionalInterface
   interface ResourceFileProcessor {

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/ApplyService.java
@@ -31,12 +31,12 @@ import io.fabric8.kubernetes.api.model.HasMetadataComparator;
 import io.fabric8.kubernetes.client.dsl.base.PatchContext;
 import io.fabric8.kubernetes.client.dsl.base.PatchType;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.summary.KubernetesResourceSummary;
 import org.eclipse.jkube.kit.common.util.FileUtil;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.common.util.UserConfigurationCompare;
 import org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil;
 
@@ -116,13 +116,15 @@ public class ApplyService {
     private boolean rollingUpgradePreserveScale = true;
     private boolean recreateMode;
     private final PatchService patchService;
+    private final SummaryService summaryService;
     // This map is to track projects created.
     private static final Set<String> projectsCreated = new HashSet<>();
 
-    public ApplyService(KubernetesClient kubernetesClient, KitLogger log) {
+    public ApplyService(KubernetesClient kubernetesClient, KitLogger log, SummaryService summaryService) {
         this.kubernetesClient = kubernetesClient;
         this.patchService = new PatchService(kubernetesClient, log);
         this.log = log;
+        this.summaryService = summaryService;
     }
 
     /**
@@ -1367,7 +1369,7 @@ public class ApplyService {
     public void applyEntities(String fileName, Collection<HasMetadata> entities, KitLogger serviceLogger,
                                  long serviceUrlWaitTimeSeconds) {
 
-        SummaryUtil.setAppliedClusterUrl(kubernetesClient.getMasterUrl().toString());
+        summaryService.setAppliedClusterUrl(kubernetesClient.getMasterUrl().toString());
         applyStandardEntities(fileName, getK8sListWithNamespaceFirst(entities));
     }
 
@@ -1389,7 +1391,7 @@ public class ApplyService {
     }
 
     private void addToAppliedResourcesSummary(HasMetadata h, String applicableNamespace) {
-        SummaryUtil.addAppliedKubernetesResource(KubernetesResourceSummary.builder()
+        summaryService.addAppliedKubernetesResource(KubernetesResourceSummary.builder()
                 .group(trimGroup(h.getApiVersion()))
                 .version(trimVersion(h.getApiVersion()))
                 .namespace(applicableNamespace)

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildService.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 
 import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.RegistryConfig;
 import org.eclipse.jkube.kit.config.resource.RuntimeMode;
@@ -50,7 +51,11 @@ public class DockerBuildService extends AbstractImageBuildService {
 
     @Override
     public boolean isApplicable() {
-        return runtimeMode == RuntimeMode.KUBERNETES;
+        if (runtimeMode == RuntimeMode.KUBERNETES) {
+            SummaryUtil.setBuildStrategy("Local Docker");
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildService.java
@@ -26,6 +26,7 @@ import org.eclipse.jkube.kit.common.AssemblyFileEntry;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.archive.ArchiveCompression;
 import org.eclipse.jkube.kit.common.util.EnvUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.common.RegistryConfig;
@@ -70,7 +71,11 @@ public class JibBuildService extends AbstractImageBuildService {
 
     @Override
     public boolean isApplicable() {
-        return buildServiceConfig.getJKubeBuildStrategy() == JKubeBuildStrategy.jib;
+        if (buildServiceConfig.getJKubeBuildStrategy() == JKubeBuildStrategy.jib) {
+            SummaryUtil.setBuildStrategy("Local Jib");
+            return true;
+        }
+        return false;
     }
 
     @Override

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployService.java
@@ -28,7 +28,6 @@ import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.summary.KubernetesResourceSummary;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 import org.eclipse.jkube.kit.config.service.UndeployService;
@@ -67,7 +66,7 @@ public class KubernetesUndeployService implements UndeployService {
       logger.warn("No such generated manifests found for this project, ignoring.");
       return;
     }
-    SummaryUtil.setUndeployedClusterUrl(jKubeServiceHub.getClient().getMasterUrl().toString());
+    jKubeServiceHub.getSummaryService().setUndeployedClusterUrl(jKubeServiceHub.getClient().getMasterUrl().toString());
     List<HasMetadata> undeployEntities = getK8sListWithNamespaceFirst(entities);
     Collections.reverse(undeployEntities);
     undeployCustomResources(resourceConfig.getNamespace(), fallbackNamespace, undeployEntities);
@@ -123,7 +122,7 @@ public class KubernetesUndeployService implements UndeployService {
   }
 
   private void addToUndeployedResourcesSummary(String namespace, HasMetadata h) {
-    SummaryUtil.addDeletedKubernetesResource(KubernetesResourceSummary.builder()
+    jKubeServiceHub.getSummaryService().addDeletedKubernetesResource(KubernetesResourceSummary.builder()
         .group(trimGroup(h.getApiVersion()))
         .version(trimVersion(h.getApiVersion()))
         .namespace(namespace)

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/SummaryServiceUtil.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/SummaryServiceUtil.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.service.kubernetes;
+
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+
+public class SummaryServiceUtil {
+  private SummaryServiceUtil() { }
+
+  public static void printSummary(JKubeServiceHub jKubeServiceHub) {
+    if (jKubeServiceHub != null) {
+      jKubeServiceHub.getSummaryService().printSummary(jKubeServiceHub.getConfiguration().getBasedir());
+      jKubeServiceHub.getSummaryService().clear();
+    }
+  }
+
+  public static void printSummaryIfLastExecuting(JKubeServiceHub jKubeServiceHub, String current, String lastExecuting) {
+    if (lastExecuting != null && lastExecuting.equals(current)) {
+      printSummary(jKubeServiceHub);
+    }
+  }
+
+  public static void handleExceptionAndSummary(JKubeServiceHub jKubeServiceHub, Exception exception) {
+    if (jKubeServiceHub != null) {
+      jKubeServiceHub.getSummaryService().setFailureAndCause(exception.getMessage());
+      printSummary(jKubeServiceHub);
+    }
+  }
+}

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceUtils.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceUtils.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.build.api.assembly.ArchiverCustomizer;
 import org.eclipse.jkube.kit.common.util.IoUtil;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
@@ -63,7 +62,7 @@ public class OpenShiftBuildServiceUtils {
     final ArchiverCustomizer customizer = createS2IArchiveCustomizer(jKubeServiceHub.getBuildServiceConfig(), imageConfig);
     try {
       return jKubeServiceHub.getDockerServiceHub().getArchiveService()
-          .createDockerBuildArchive(imageConfig, jKubeServiceHub.getConfiguration(), customizer);
+          .createDockerBuildArchive(imageConfig, jKubeServiceHub.getConfiguration(), customizer, jKubeServiceHub.getSummaryService());
     } catch (IOException e) {
       throw new JKubeServiceException("Unable to create the build archive", e);
     }
@@ -124,7 +123,7 @@ public class OpenShiftBuildServiceUtils {
     final String fromNamespace = getMapValueWithDefault(fromExt, JKubeBuildStrategy.SourceStrategy.namespace,
         IMAGE_STREAM_TAG.equals(fromKind) ? "openshift" : null);
     if (osBuildStrategy == JKubeBuildStrategy.docker) {
-      SummaryUtil.setBuildStrategy("Cluster Docker");
+      jKubeServiceHub.getSummaryService().setBuildStrategy("Cluster Docker");
       BuildStrategy buildStrategy = new BuildStrategyBuilder()
           .withType("Docker")
           .withNewDockerStrategy()
@@ -143,7 +142,7 @@ public class OpenShiftBuildServiceUtils {
       }
       return buildStrategy;
     } else if (osBuildStrategy == JKubeBuildStrategy.s2i) {
-      SummaryUtil.setBuildStrategy("Cluster S2I");
+      jKubeServiceHub.getSummaryService().setBuildStrategy("Cluster S2I");
       BuildStrategy buildStrategy = new BuildStrategyBuilder()
           .withType("Source")
           .withNewSourceStrategy()

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceUtils.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceUtils.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.build.api.assembly.ArchiverCustomizer;
 import org.eclipse.jkube.kit.common.util.IoUtil;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
@@ -123,6 +124,7 @@ public class OpenShiftBuildServiceUtils {
     final String fromNamespace = getMapValueWithDefault(fromExt, JKubeBuildStrategy.SourceStrategy.namespace,
         IMAGE_STREAM_TAG.equals(fromKind) ? "openshift" : null);
     if (osBuildStrategy == JKubeBuildStrategy.docker) {
+      SummaryUtil.setBuildStrategy("Cluster Docker");
       BuildStrategy buildStrategy = new BuildStrategyBuilder()
           .withType("Docker")
           .withNewDockerStrategy()
@@ -141,6 +143,7 @@ public class OpenShiftBuildServiceUtils {
       }
       return buildStrategy;
     } else if (osBuildStrategy == JKubeBuildStrategy.s2i) {
+      SummaryUtil.setBuildStrategy("Cluster S2I");
       BuildStrategy buildStrategy = new BuildStrategyBuilder()
           .withType("Source")
           .withNewSourceStrategy()

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
@@ -34,6 +34,7 @@ import org.eclipse.jkube.kit.common.ResourceFileType;
 import org.eclipse.jkube.kit.common.util.EnvUtil;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.common.RegistryConfig;
@@ -151,6 +152,8 @@ public class OpenshiftBuildService extends AbstractImageBuildService {
 
                 // Create a file with generated image streams
                 addImageStreamToFile(getImageStreamFile(), imageName, client);
+                SummaryUtil.setBaseImageNameImageSummary(imageConfig.getName(), imageConfig.getBuildConfiguration().getFrom());
+                SummaryUtil.setImageStreamUsedImageSummary(imageConfig.getName(), resolveImageStreamName(imageName));
 
                 createAdditionalTags(imageConfig, imageName);
             } else {
@@ -206,6 +209,7 @@ public class OpenshiftBuildService extends AbstractImageBuildService {
 
         // Fetch existing build config
         BuildConfig buildConfig = client.buildConfigs().inNamespace(applicableOpenShiftNamespace).withName(buildName).get();
+        SummaryUtil.setOpenShiftBuildConfigName(buildName);
         if (buildConfig != null) {
             // lets verify the BC
             BuildConfigSpec spec = OpenShiftBuildServiceUtils.getBuildConfigSpec(buildConfig);

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
@@ -34,7 +34,6 @@ import org.eclipse.jkube.kit.common.ResourceFileType;
 import org.eclipse.jkube.kit.common.util.EnvUtil;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.common.RegistryConfig;
@@ -152,8 +151,8 @@ public class OpenshiftBuildService extends AbstractImageBuildService {
 
                 // Create a file with generated image streams
                 addImageStreamToFile(getImageStreamFile(), imageName, client);
-                SummaryUtil.setBaseImageNameImageSummary(imageConfig.getName(), imageConfig.getBuildConfiguration().getFrom());
-                SummaryUtil.setImageStreamUsedImageSummary(imageConfig.getName(), resolveImageStreamName(imageName));
+                jKubeServiceHub.getSummaryService().setBaseImageNameImageSummary(imageConfig.getName(), imageConfig.getBuildConfiguration().getFrom());
+                jKubeServiceHub.getSummaryService().setImageStreamUsedImageSummary(imageConfig.getName(), resolveImageStreamName(imageName));
 
                 createAdditionalTags(imageConfig, imageName);
             } else {
@@ -209,7 +208,7 @@ public class OpenshiftBuildService extends AbstractImageBuildService {
 
         // Fetch existing build config
         BuildConfig buildConfig = client.buildConfigs().inNamespace(applicableOpenShiftNamespace).withName(buildName).get();
-        SummaryUtil.setOpenShiftBuildConfigName(buildName);
+        jKubeServiceHub.getSummaryService().setOpenShiftBuildConfigName(buildName);
         if (buildConfig != null) {
             // lets verify the BC
             BuildConfigSpec spec = OpenShiftBuildServiceUtils.getBuildConfigSpec(buildConfig);

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/ApplyServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/ApplyServiceTest.java
@@ -35,6 +35,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.service.openshift.WebServerEventCollector;
 
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
@@ -60,10 +61,12 @@ import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 @EnableKubernetesMockClient
 class ApplyServiceTest {
     private KitLogger log;
+    private SummaryService summaryService;
 
     KubernetesMockServer mockServer;
     OpenShiftClient client;
@@ -73,7 +76,8 @@ class ApplyServiceTest {
     @BeforeEach
     void setUp() {
         log = new KitLogger.SilentLogger();
-        applyService = new ApplyService(client, log);
+        summaryService = mock(SummaryService.class);
+        applyService = new ApplyService(client, log, summaryService);
         applyService.setNamespace("default");
     }
 

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/DebugServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/DebugServiceTest.java
@@ -42,6 +42,7 @@ import io.fabric8.openshift.client.OpenShiftClient;
 import okhttp3.mockwebserver.RecordedRequest;
 import org.assertj.core.groups.Tuple;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -61,6 +62,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.startsWith;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
@@ -78,8 +80,9 @@ class DebugServiceTest {
   @BeforeEach
   void setUp() {
     logger = spy(new KitLogger.SilentLogger());
+    SummaryService summaryService = mock(SummaryService.class);
     singleThreadExecutor = Executors.newSingleThreadExecutor();
-    final ApplyService applyService = new ApplyService(kubernetesClient, logger);
+    final ApplyService applyService = new ApplyService(kubernetesClient, logger, summaryService);
     applyService.setNamespace(kubernetesClient.getNamespace());
     debugService = new DebugService(logger, kubernetesClient, new PortForwardService(logger), applyService);
   }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/JKubeServiceHubBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/JKubeServiceHubBuildServiceTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.kit.config.service;
 
+import java.io.File;
 import java.util.stream.Stream;
 
 import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
@@ -33,6 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class JKubeServiceHubBuildServiceTest {
 
@@ -55,9 +57,11 @@ class JKubeServiceHubBuildServiceTest {
       Class<? extends BuildService> buildServiceClass) {
     // Given
     final BuildServiceConfig config = BuildServiceConfig.builder().jKubeBuildStrategy(buildStrategy).build();
+    final JKubeConfiguration jKubeConfiguration = mock(JKubeConfiguration.class);
+    when(jKubeConfiguration.getBuildDirectory()).thenReturn(new File("target"));
     final JKubeServiceHub jKubeServiceHub = new JKubeServiceHub(null, runtimeMode, new KitLogger.StdoutLogger(),
-        mock(DockerServiceHub.class, RETURNS_DEEP_STUBS), new JKubeConfiguration(), config, new LazyBuilder<>(() -> null),
-        true);
+        mock(DockerServiceHub.class, RETURNS_DEEP_STUBS), jKubeConfiguration, config, new LazyBuilder<>(() -> null),
+        true, false);
     // When
     final BuildService result = jKubeServiceHub.getBuildService();
     // Then

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildServiceTest.java
@@ -73,7 +73,7 @@ class DockerBuildServiceTest {
     new DockerBuildService(mockedJKubeServiceHub).build(image);
     // Then
     verify(mockedDockerBuildService, times(0))
-        .buildImage(eq(image), any(), any());
+        .buildImage(eq(image), any(), any(), any());
     verify(mockedDockerBuildService, times(0))
         .tagImage(anyString(), eq(image));
   }
@@ -84,7 +84,7 @@ class DockerBuildServiceTest {
     new DockerBuildService(mockedJKubeServiceHub).build(image);
     // Then
     verify(mockedDockerBuildService, times(1))
-        .buildImage(eq(image), any(), any());
+        .buildImage(eq(image), any(), any(), any());
     verify(mockedDockerBuildService, times(1))
         .tagImage("image-name", image);
   }
@@ -104,7 +104,7 @@ class DockerBuildServiceTest {
     new DockerBuildService(mockedJKubeServiceHub).build(imageWithSkipEnabled);
     // Then
     verify(mockedDockerBuildService, times(0))
-        .buildImage(eq(image), any(), any());
+        .buildImage(eq(image), any(), any(), any());
     verify(mockedDockerBuildService, times(0))
         .tagImage(anyString(), eq(image));
   }
@@ -112,7 +112,7 @@ class DockerBuildServiceTest {
   @Test
   void build_withFailure_shouldThrowException() throws Exception {
     // Given
-    doThrow(new IOException("Mock IO error")).when(mockedDockerBuildService).buildImage(eq(image), any(), any());
+    doThrow(new IOException("Mock IO error")).when(mockedDockerBuildService).buildImage(eq(image), any(), any(), any());
     // When + Then
     assertThatExceptionOfType(JKubeServiceException.class)
         .isThrownBy(() -> new DockerBuildService(mockedJKubeServiceHub).build(image))
@@ -125,7 +125,7 @@ class DockerBuildServiceTest {
     new DockerBuildService(mockedJKubeServiceHub).push(Collections.emptyList(), 0, null, false);
     // Then
     verify(mockedJKubeServiceHub.getDockerServiceHub().getRegistryService(), times(0))
-        .pushImage(any(), eq(0), isNull(), eq(false));
+        .pushImage(any(), eq(0), isNull(), eq(false), any());
   }
 
   @Test
@@ -134,6 +134,6 @@ class DockerBuildServiceTest {
     new DockerBuildService(mockedJKubeServiceHub).build(imageWithSkipEnabled);
     // Then
     verify(mockedJKubeServiceHub.getDockerServiceHub().getRegistryService(), times(0))
-        .pushImage(any(), eq(0), isNull(), eq(false));
+        .pushImage(any(), eq(0), isNull(), eq(false), any());
   }
 }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/JibBuildServiceTest.java
@@ -157,7 +157,7 @@ class JibBuildServiceTest {
         // Given
         File projectBaseDir = Files.createDirectory(temporaryFolder.resolve("test")).toFile();
         // When
-        File tarArchive = JibBuildService.getAssemblyTarArchive(imageConfiguration, createJKubeConfiguration(projectBaseDir), mockedLogger);
+        File tarArchive = JibBuildService.getAssemblyTarArchive(imageConfiguration, createJKubeConfiguration(projectBaseDir), mockedLogger, mockedServiceHub.getSummaryService());
         // Then
         assertThat(tarArchive).isNotNull()
             .isEqualTo(projectBaseDir.toPath().resolve("target").resolve("test").resolve("testimage").resolve("0.0.1")
@@ -178,7 +178,7 @@ class JibBuildServiceTest {
         // When
         new JibBuildService(mockedServiceHub).push(Collections.emptyList(), 1, null, false);
         // Then
-        jibServiceUtilMockedStatic.verify(() -> JibServiceUtil.jibPush(any(), any(), any(), eq(mockedLogger)), times(0));
+        jibServiceUtilMockedStatic.verify(() -> JibServiceUtil.jibPush(any(), any(), any(), eq(mockedLogger), any()), times(0));
     }
 
     @Test
@@ -187,7 +187,7 @@ class JibBuildServiceTest {
             // When
             new JibBuildService(mockedServiceHub).push(Collections.singletonList(imageConfiguration), 1, registryConfig, false);
             // Then
-            jibServiceUtilMockedStatic.verify(() -> JibServiceUtil.jibPush(eq(imageConfiguration), eq(Credential.from("testuserpush", "testpass")), any(), eq(mockedLogger)), times(1));
+            jibServiceUtilMockedStatic.verify(() -> JibServiceUtil.jibPush(eq(imageConfiguration), eq(Credential.from("testuserpush", "testpass")), any(), eq(mockedLogger), any()), times(1));
         }
     }
 
@@ -204,7 +204,7 @@ class JibBuildServiceTest {
         // When
         new JibBuildService(mockedServiceHub).push(Collections.singletonList(imageConfiguration), 1, registryConfig, false);
         // Then
-        jibServiceUtilMockedStatic.verify(() -> JibServiceUtil.jibPush(any(), any(), any(), any()), times(0));
+        jibServiceUtilMockedStatic.verify(() -> JibServiceUtil.jibPush(any(), any(), any(), any(), any()), times(0));
     }
 
     @Test

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/KubernetesUndeployServiceTest.java
@@ -34,6 +34,7 @@ import io.fabric8.kubernetes.client.server.mock.KubernetesMockServer;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.access.ClusterConfiguration;
@@ -73,7 +74,11 @@ class KubernetesUndeployServiceTest {
     final JKubeServiceHub jKubeServiceHub = JKubeServiceHub.builder()
       .log(logger)
       .platformMode(RuntimeMode.KUBERNETES)
-      .configuration(JKubeConfiguration.builder().build())
+      .configuration(JKubeConfiguration.builder()
+          .project(JavaProject.builder()
+              .buildDirectory(new File("target"))
+              .build())
+          .build())
       .clusterAccess(new ClusterAccess(logger, ClusterConfiguration.builder().namespace("test").build()) {
         @Override
         public <T extends KubernetesClient> T createDefaultClient() {

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/SummaryServiceUtilTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/SummaryServiceUtilTest.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.config.service.kubernetes;
+
+import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.common.service.SummaryService;
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SummaryServiceUtilTest {
+  private JKubeServiceHub mockedJKubeServiceHub;
+  private SummaryService mockedSummaryService;
+
+  @BeforeEach
+  public void setUp() {
+    JKubeConfiguration mockedJKubeConfiguration = mock(JKubeConfiguration.class);
+    when(mockedJKubeConfiguration.getBasedir()).thenReturn(new File("test"));
+    mockedJKubeServiceHub = mock(JKubeServiceHub.class);
+    mockedSummaryService = mock(SummaryService.class);
+    when(mockedJKubeServiceHub.getSummaryService()).thenReturn(mockedSummaryService);
+    when(mockedJKubeServiceHub.getConfiguration()).thenReturn(mockedJKubeConfiguration);
+  }
+
+  @Test
+  void printSummary_whenNullJKubeServiceHub_thenDoesNothing() {
+    // Given + When
+    SummaryServiceUtil.printSummary(null);
+
+    // Then
+    verify(mockedJKubeServiceHub, times(0)).getSummaryService();
+  }
+
+  @Test
+  void printSummary_whenJKubeServiceHub_thenPrintsSummary() {
+    // Given + When
+    SummaryServiceUtil.printSummary(mockedJKubeServiceHub);
+
+    // Then
+    verifySummaryPrinted(2);
+  }
+
+  @Test
+  void printSummaryIfLastExecuting_whenLastExecutingNull_thenPrintsNothing() {
+    // Given + When
+    SummaryServiceUtil.printSummaryIfLastExecuting(mockedJKubeServiceHub, "resource", null);
+
+    // Then
+    verify(mockedJKubeServiceHub, times(0)).getSummaryService();
+  }
+
+  @Test
+  void printSummaryIfLastExecuting_whenLastExecutingAndCurrentDifferent_thenPrintsNothing() {
+    // Given + When
+    SummaryServiceUtil.printSummaryIfLastExecuting(mockedJKubeServiceHub, "resource", "apply");
+
+    // Then
+    verify(mockedJKubeServiceHub, times(0)).getSummaryService();
+  }
+
+  @Test
+  void printSummaryIfLastExecuting_whenLastExecutingAndCurrentSame_thenPrintsSummary() {
+    // Given + When
+    SummaryServiceUtil.printSummaryIfLastExecuting(mockedJKubeServiceHub, "resource",  "resource");
+
+    // Then
+    verifySummaryPrinted(2);
+  }
+
+  @Test
+  void handleExceptionAndSummary_whenInvoked_thenSetsFailureAndPrintsSummary() {
+    // Given + When
+    SummaryServiceUtil.handleExceptionAndSummary(mockedJKubeServiceHub, new IOException("failure"));
+
+    // Then
+    verifySummaryPrinted(3);
+    verify(mockedSummaryService).setFailureAndCause("failure");
+  }
+
+
+  private void verifySummaryPrinted(int summaryServiceInvocations) {
+    verify(mockedJKubeServiceHub, times(summaryServiceInvocations)).getSummaryService();
+    verify(mockedSummaryService).printSummary(any());
+    verify(mockedSummaryService).clear();
+  }
+
+}

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceTest.java
@@ -120,7 +120,7 @@ class OpenShiftBuildServiceTest {
 
     // Then
     verify(mockedArchiveService, times(0))
-        .createDockerBuildArchive(any(), any(), any());
+        .createDockerBuildArchive(any(), any(), any(), any());
   }
 
   @Test

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceUtilsTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceUtilsTest.java
@@ -93,7 +93,7 @@ class OpenShiftBuildServiceUtilsTest {
   void createBuildArchive_withIOExceptionOnCreateDockerBuildArchive_shouldThrowException() throws Exception {
     // Given
     when(jKubeServiceHub.getDockerServiceHub().getArchiveService().createDockerBuildArchive(
-        any(ImageConfiguration.class), any(JKubeConfiguration.class), any(ArchiverCustomizer.class)))
+        any(ImageConfiguration.class), any(JKubeConfiguration.class), any(ArchiverCustomizer.class), any()))
         .thenThrow(new IOException("Mocked Exception"));
     // When + Then
     assertThatExceptionOfType(JKubeServiceException.class)
@@ -249,7 +249,7 @@ class OpenShiftBuildServiceUtilsTest {
 
     final ArgumentCaptor<ArchiverCustomizer> customizer = ArgumentCaptor.forClass(ArchiverCustomizer.class);
     verify(jKubeServiceHub.getDockerServiceHub().getArchiveService(), times(1))
-        .createDockerBuildArchive(any(ImageConfiguration.class), any(JKubeConfiguration.class), customizer.capture());
+        .createDockerBuildArchive(any(ImageConfiguration.class), any(JKubeConfiguration.class), customizer.capture(), any());
 
     customizer.getValue().customize(tarArchiver);
     final ArgumentCaptor<String> path = ArgumentCaptor.forClass(String.class);

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftUndeployServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftUndeployServiceTest.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.client.server.mock.EnableKubernetesMockClient;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.access.ClusterConfiguration;
@@ -74,7 +75,11 @@ class OpenshiftUndeployServiceTest {
     final JKubeServiceHub jKubeServiceHub = JKubeServiceHub.builder()
       .log(logger)
       .platformMode(RuntimeMode.KUBERNETES)
-      .configuration(JKubeConfiguration.builder().build())
+      .configuration(JKubeConfiguration.builder()
+          .project(JavaProject.builder()
+              .buildDirectory(new File("target"))
+              .build())
+          .build())
       .clusterAccess(new ClusterAccess(logger, ClusterConfiguration.builder().namespace("test").build()) {
         @Override
         public <T extends KubernetesClient> T createDefaultClient() {

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/plugins/PluginManagerTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/plugins/PluginManagerTest.java
@@ -35,7 +35,7 @@ class PluginManagerTest {
   @BeforeEach
   void setUp() {
     jKubeServiceHub = new JKubeServiceHub(null, RuntimeMode.KUBERNETES, new KitLogger.StdoutLogger(),
-      null, new JKubeConfiguration(), new BuildServiceConfig(), new LazyBuilder<>(() -> null), true);
+      null, new JKubeConfiguration(), new BuildServiceConfig(), new LazyBuilder<>(() -> null), true, false);
   }
 
   @Test

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/plugins/PluginServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/plugins/PluginServiceTest.java
@@ -57,7 +57,7 @@ class PluginServiceTest {
           .outputDirectory(temporaryFolder)
           .build())
         .build(),
-      new BuildServiceConfig(), new LazyBuilder<>(() -> null), true);
+      new BuildServiceConfig(), new LazyBuilder<>(() -> null), true, false);
   }
 
   @Test

--- a/jkube-kit/doc/src/main/asciidoc/inc/_summary.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/_summary.adoc
@@ -1,0 +1,15 @@
+[[summary]]
+= Summary
+
+{plugin} can print a brief summary of the task it performed in order to give better idea of what's going on to the user. At the moment, most of the build related actions (build, push, resource, apply etc.) print summary. It can be disabled with `jkube.summaryEnabled` property.
+
+.Summary configuration
+[cols="2,6"]
+|===
+| Property | Description
+
+| `jkube.summaryEnabled`
+| Whether summary should be printed or not.
+
+Defaults to `true`
+|===

--- a/jkube-kit/doc/src/main/asciidoc/inc/_summary.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/_summary.adoc
@@ -1,7 +1,7 @@
 [[summary]]
 = Summary
 
-{plugin} can print a brief summary of the task it performed in order to give better idea of what's going on to the user. At the moment, most of the build related actions (build, push, resource, apply etc.) print summary. It can be disabled with `jkube.summaryEnabled` property.
+{plugin} prints a brief summary of the task it performed in order to give better idea of what's going on to the user. At the moment, most of the build related actions (build, push, resource, apply etc.) print summary. It can be disabled with `jkube.summaryEnabled` property.
 
 .Summary configuration
 [cols="2,6"]

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/EnricherContext.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/EnricherContext.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import org.eclipse.jkube.kit.common.Dependency;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
 import org.eclipse.jkube.kit.enricher.api.model.Configuration;
 import org.eclipse.jkube.kit.common.util.ProjectClassLoaders;
@@ -135,4 +136,5 @@ public interface EnricherContext {
      * @return the Handler Hub instance.
      */
     HandlerHub getHandlerHub();
+    SummaryService getSummaryService();
 }

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/JKubeEnricherContext.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/JKubeEnricherContext.java
@@ -28,6 +28,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Singular;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.RegistryServerConfiguration;
 import org.eclipse.jkube.kit.common.JavaProject;
@@ -73,13 +74,15 @@ public class JKubeEnricherContext implements EnricherContext {
     private HandlerHub handlerHub;
     @Getter(AccessLevel.NONE)
     private JKubeBuildStrategy jKubeBuildStrategy;
+    private SummaryService summaryService;
 
 
     @Builder(toBuilder = true)
     public JKubeEnricherContext(
         @Singular  List<RegistryServerConfiguration> settings, @Singular Map<String, String> processingInstructions,
         JavaProject project, KitLogger log,
-        ResourceConfig resources, @Singular List<ImageConfiguration> images, ProcessorConfig processorConfig, JKubeBuildStrategy jKubeBuildStrategy) {
+        ResourceConfig resources, @Singular List<ImageConfiguration> images, ProcessorConfig processorConfig,
+        JKubeBuildStrategy jKubeBuildStrategy, SummaryService summaryService) {
         this.settings = settings;
         this.processingInstructions = processingInstructions;
         this.project = project;
@@ -88,6 +91,7 @@ public class JKubeEnricherContext implements EnricherContext {
         this.images = images;
         this.processorConfig = processorConfig;
         this.handlerHub = new HandlerHub(getGav(), getProperties());
+        this.summaryService = summaryService;
         this.configuration = Configuration.builder()
             .images(images)
             .resource(resources)

--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/util/KubernetesResourceUtil.java
@@ -52,6 +52,7 @@ import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.KindFilenameMapperUtil;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.MapUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.config.resource.ControllerResourceConfig;
@@ -412,16 +413,16 @@ public class KubernetesResourceUtil {
         }
     }
 
-    public static void handleKubernetesClientException(KubernetesClientException e, KitLogger logger) {
+    public static void handleKubernetesClientException(KubernetesClientException e, KitLogger logger, boolean summaryEnabled) {
         Throwable cause = e.getCause();
         if (cause instanceof UnknownHostException) {
             logger.error( "Could not connect to kubernetes cluster!");
             logger.error( "Connection error: %s", cause);
 
             String message = "Could not connect to kubernetes cluster. Are you sure if you're connected to a remote cluster via `kubectl`? Error: " + cause;
-            throw new IllegalStateException(message, e);
+            SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, message, () -> new IllegalStateException(message, e));
         } else {
-            throw new IllegalStateException(e.getMessage(), e);
+            SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, e.getMessage(), () -> new IllegalStateException(e.getMessage(), e));
         }
     }
 

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ConfigMapEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ConfigMapEnricher.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.ConfigMapEntry;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
@@ -62,6 +63,7 @@ public class ConfigMapEnricher extends BaseEnricher {
                 final Map<String, String> annotations = element.buildMetadata().getAnnotations();
                 if (annotations != null) {
                     try {
+                        SummaryUtil.addToEnrichers(getName());
                         addConfigMapFromAnnotations(annotations, element);
                     } catch (IOException e) {
                         throw new IllegalArgumentException(e);
@@ -111,6 +113,7 @@ public class ConfigMapEnricher extends BaseEnricher {
 
             if ((configMap.getData() != null && !configMap.getData().isEmpty())
                     || (configMap.getBinaryData() != null && !configMap.getBinaryData().isEmpty())) {
+                SummaryUtil.addToEnrichers(getName());
                 builder.addToConfigMapItems(configMap);
             }
         } catch (IOException e) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ConfigMapEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ConfigMapEnricher.java
@@ -24,7 +24,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.ConfigMapEntry;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
@@ -63,7 +62,7 @@ public class ConfigMapEnricher extends BaseEnricher {
                 final Map<String, String> annotations = element.buildMetadata().getAnnotations();
                 if (annotations != null) {
                     try {
-                        SummaryUtil.addToEnrichers(getName());
+                        getContext().getSummaryService().addToEnrichers(getName());
                         addConfigMapFromAnnotations(annotations, element);
                     } catch (IOException e) {
                         throw new IllegalArgumentException(e);
@@ -113,7 +112,7 @@ public class ConfigMapEnricher extends BaseEnricher {
 
             if ((configMap.getData() != null && !configMap.getData().isEmpty())
                     || (configMap.getBinaryData() != null && !configMap.getBinaryData().isEmpty())) {
-                SummaryUtil.addToEnrichers(getName());
+                getContext().getSummaryService().addToEnrichers(getName());
                 builder.addToConfigMapItems(configMap);
             }
         } catch (IOException e) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeEnricher.java
@@ -19,6 +19,7 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -59,6 +60,7 @@ public class ContainerEnvJavaOptionsMergeEnricher extends BaseEnricher {
   @Override
   public void enrich(PlatformMode platformMode, KubernetesListBuilder builder) {
     if (!asBoolean(getConfig(Config.DISABLE)) && hasImageConfiguration()) {
+      SummaryUtil.addToEnrichers(getName());
       builder.accept(new ContainerEnvJavaOptionsMergeVisitor(getImages()));
     }
   }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ContainerEnvJavaOptionsMergeEnricher.java
@@ -19,7 +19,6 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -60,7 +59,7 @@ public class ContainerEnvJavaOptionsMergeEnricher extends BaseEnricher {
   @Override
   public void enrich(PlatformMode platformMode, KubernetesListBuilder builder) {
     if (!asBoolean(getConfig(Config.DISABLE)) && hasImageConfiguration()) {
-      SummaryUtil.addToEnrichers(getName());
+      getContext().getSummaryService().addToEnrichers(getName());
       builder.accept(new ContainerEnvJavaOptionsMergeVisitor(getImages()));
     }
   }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ControllerViaPluginConfigurationEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ControllerViaPluginConfigurationEnricher.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.ControllerResourceConfig;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -85,7 +84,7 @@ public class ControllerViaPluginConfigurationEnricher extends BaseEnricher {
         final List<ImageConfiguration> images = getImages();
         // Check if at least a replica set is added. If not add a default one
         if (KubernetesResourceUtil.checkForKind(builder, POD_CONTROLLER_KINDS)) {
-            SummaryUtil.addToEnrichers(getName());
+            getContext().getSummaryService().addToEnrichers(getName());
             // At least one image must be present, otherwise the resulting config will be invalid
             if (KubernetesResourceUtil.checkForKind(builder, "StatefulSet")) {
                 final StatefulSetSpec spec = statefulSetHandler.get(controllerResourceConfig, images).getSpec();

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ControllerViaPluginConfigurationEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ControllerViaPluginConfigurationEnricher.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.ControllerResourceConfig;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -84,6 +85,7 @@ public class ControllerViaPluginConfigurationEnricher extends BaseEnricher {
         final List<ImageConfiguration> images = getImages();
         // Check if at least a replica set is added. If not add a default one
         if (KubernetesResourceUtil.checkForKind(builder, POD_CONTROLLER_KINDS)) {
+            SummaryUtil.addToEnrichers(getName());
             // At least one image must be present, otherwise the resulting config will be invalid
             if (KubernetesResourceUtil.checkForKind(builder, "StatefulSet")) {
                 final StatefulSetSpec spec = statefulSetHandler.get(controllerResourceConfig, images).getSpec();

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DebugEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DebugEnricher.java
@@ -31,7 +31,6 @@ import io.fabric8.openshift.api.model.DeploymentConfigSpec;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -69,7 +68,7 @@ public class DebugEnricher extends BaseEnricher {
     @Override
     public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
         if (isDebugEnabled()) {
-            SummaryUtil.addToEnrichers(getName());
+            getContext().getSummaryService().addToEnrichers(getName());
             int count = 0;
             List<HasMetadata> items = builder.buildItems();
             if (items != null) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DebugEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DebugEnricher.java
@@ -31,6 +31,7 @@ import io.fabric8.openshift.api.model.DeploymentConfigSpec;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -68,6 +69,7 @@ public class DebugEnricher extends BaseEnricher {
     @Override
     public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
         if (isDebugEnabled()) {
+            SummaryUtil.addToEnrichers(getName());
             int count = 0;
             List<HasMetadata> items = builder.buildItems();
             if (items != null) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
@@ -28,7 +28,6 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.ControllerResourceConfig;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -118,7 +117,7 @@ public class DefaultControllerEnricher extends BaseEnricher {
           .getHandlerFor(fromType(getConfig(Config.TYPE)));
       final HasMetadata resource = ch.get(controllerResourceConfig, images);
       log.info("Adding a default %s", resource.getKind());
-      SummaryUtil.addToEnrichers(getName());
+      getContext().getSummaryService().addToEnrichers(getName());
       builder.addToItems(resource);
       setProcessingInstruction(FABRIC8_GENERATED_CONTAINERS,
           getContainersFromPodSpec(ch.getPodTemplateSpec(controllerResourceConfig, images)));

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricher.java
@@ -28,6 +28,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.ControllerResourceConfig;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -117,6 +118,7 @@ public class DefaultControllerEnricher extends BaseEnricher {
           .getHandlerFor(fromType(getConfig(Config.TYPE)));
       final HasMetadata resource = ch.get(controllerResourceConfig, images);
       log.info("Adding a default %s", resource.getKind());
+      SummaryUtil.addToEnrichers(getName());
       builder.addToItems(resource);
       setProcessingInstruction(FABRIC8_GENERATED_CONTAINERS,
           getContainersFromPodSpec(ch.getPodTemplateSpec(controllerResourceConfig, images)));

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultMetadataEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultMetadataEnricher.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.enricher.generic;
 
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -70,6 +71,7 @@ public class DefaultMetadataEnricher extends BaseEnricher {
     }
 
     private void visit(KubernetesListBuilder builder, MetadataVisitor<?>[] visitors) {
+        SummaryUtil.addToEnrichers(getName());
         for (MetadataVisitor<?> visitor : visitors) {
             builder.accept(visitor);
         }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultMetadataEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultMetadataEnricher.java
@@ -13,7 +13,6 @@
  */
 package org.eclipse.jkube.enricher.generic;
 
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -71,7 +70,7 @@ public class DefaultMetadataEnricher extends BaseEnricher {
     }
 
     private void visit(KubernetesListBuilder builder, MetadataVisitor<?>[] visitors) {
-        SummaryUtil.addToEnrichers(getName());
+        getContext().getSummaryService().addToEnrichers(getName());
         for (MetadataVisitor<?> visitor : visitors) {
             builder.accept(visitor);
         }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricher.java
@@ -25,6 +25,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -99,6 +100,7 @@ public class DefaultNamespaceEnricher extends BaseEnricher {
 
                 boolean forceModifyNamespace = Boolean.parseBoolean(getConfig(Config.FORCE));
                 if (StringUtils.isBlank(metaBuilder.getNamespace()) || forceModifyNamespace) {
+                    SummaryUtil.addToEnrichers(getName());
                     metaBuilder.withNamespace(getNamespaceName()).build();
                 }
             }
@@ -145,6 +147,7 @@ public class DefaultNamespaceEnricher extends BaseEnricher {
     private void addNamespaceToBuilder(PlatformMode platformMode, String newNamespaceToCreate, KubernetesListBuilder builder, String type) {
         HasMetadata namespaceOrProject = getNamespaceOrProject(platformMode, type, newNamespaceToCreate);
         if (namespaceOrProject != null) {
+            SummaryUtil.addToEnrichers(getName());
             builder.addToItems(namespaceOrProject);
         }
     }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricher.java
@@ -25,7 +25,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -100,7 +99,7 @@ public class DefaultNamespaceEnricher extends BaseEnricher {
 
                 boolean forceModifyNamespace = Boolean.parseBoolean(getConfig(Config.FORCE));
                 if (StringUtils.isBlank(metaBuilder.getNamespace()) || forceModifyNamespace) {
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     metaBuilder.withNamespace(getNamespaceName()).build();
                 }
             }
@@ -147,7 +146,7 @@ public class DefaultNamespaceEnricher extends BaseEnricher {
     private void addNamespaceToBuilder(PlatformMode platformMode, String newNamespaceToCreate, KubernetesListBuilder builder, String type) {
         HasMetadata namespaceOrProject = getNamespaceOrProject(platformMode, type, newNamespaceToCreate);
         if (namespaceOrProject != null) {
-            SummaryUtil.addToEnrichers(getName());
+            getContext().getSummaryService().addToEnrichers(getName());
             builder.addToItems(namespaceOrProject);
         }
     }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
@@ -27,7 +27,6 @@ import io.fabric8.kubernetes.api.model.ServiceSpec;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
@@ -128,7 +127,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
     public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
 
         final ResourceConfig xmlConfig = getConfiguration().getResource();
-        SummaryUtil.addToEnrichers(getName());
+        getContext().getSummaryService().addToEnrichers(getName());
         if (Optional.ofNullable(xmlConfig).map(ResourceConfig::getServices).map(c -> !c.isEmpty()).orElse(false)) {
             // Add Services configured via XML
             addServices(builder, xmlConfig.getServices());

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.ServiceSpec;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
@@ -127,6 +128,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
     public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
 
         final ResourceConfig xmlConfig = getConfiguration().getResource();
+        SummaryUtil.addToEnrichers(getName());
         if (Optional.ofNullable(xmlConfig).map(ResourceConfig::getServices).map(c -> !c.isEmpty()).orElse(false)) {
             // Add Services configured via XML
             addServices(builder, xmlConfig.getServices());

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DependencyEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DependencyEnricher.java
@@ -22,7 +22,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.Dependency;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -89,7 +88,7 @@ public class DependencyEnricher extends BaseEnricher {
                 File file = artifact.getFile();
                 try {
                     URI uri = new URI("jar:" + file.toURI() + "!/" + dependencyYaml);
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     artifactSet.add(uri);
                 } catch (URISyntaxException e) {
                     getLog().debug("Failed to create URL for %s: %s", file, e);

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DependencyEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DependencyEnricher.java
@@ -22,6 +22,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.Dependency;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -88,6 +89,7 @@ public class DependencyEnricher extends BaseEnricher {
                 File file = artifact.getFile();
                 try {
                     URI uri = new URI("jar:" + file.toURI() + "!/" + dependencyYaml);
+                    SummaryUtil.addToEnrichers(getName());
                     artifactSet.add(uri);
                 } catch (URISyntaxException e) {
                     getLog().debug("Failed to create URL for %s: %s", file, e);

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DockerRegistrySecretEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DockerRegistrySecretEnricher.java
@@ -15,7 +15,6 @@ package org.eclipse.jkube.enricher.generic;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.api.model.Configuration;
 import org.eclipse.jkube.kit.enricher.api.util.SecretConstants;
@@ -65,7 +64,7 @@ public class DockerRegistrySecretEnricher extends SecretEnricher {
 
         JsonObject ret = new JsonObject();
         ret.add(dockerId, params);
-        SummaryUtil.addToEnrichers(getName());
+        getContext().getSummaryService().addToEnrichers(getName());
         return Collections.singletonMap(
             SecretConstants.DOCKER_DATA_KEY,
             encode(ret.toString()));

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DockerRegistrySecretEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DockerRegistrySecretEnricher.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.enricher.generic;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.api.model.Configuration;
 import org.eclipse.jkube.kit.enricher.api.util.SecretConstants;
@@ -64,6 +65,7 @@ public class DockerRegistrySecretEnricher extends SecretEnricher {
 
         JsonObject ret = new JsonObject();
         ret.add(dockerId, params);
+        SummaryUtil.addToEnrichers(getName());
         return Collections.singletonMap(
             SecretConstants.DOCKER_DATA_KEY,
             encode(ret.toString()));

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/FileDataSecretEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/FileDataSecretEnricher.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import org.eclipse.jkube.kit.common.util.Base64Util;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -56,6 +57,7 @@ public class FileDataSecretEnricher extends BaseEnricher {
                 try {
                     if (annotations != null && !annotations.isEmpty()) {
                         final Map<String, String> secretAnnotations = createSecretFromAnnotations(annotations);
+                        SummaryUtil.addToEnrichers(getName());
                         element.addToData(secretAnnotations);
                     }
                 } catch (IOException e) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/FileDataSecretEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/FileDataSecretEnricher.java
@@ -17,7 +17,6 @@ import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import org.eclipse.jkube.kit.common.util.Base64Util;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -57,7 +56,7 @@ public class FileDataSecretEnricher extends BaseEnricher {
                 try {
                     if (annotations != null && !annotations.isEmpty()) {
                         final Map<String, String> secretAnnotations = createSecretFromAnnotations(annotations);
-                        SummaryUtil.addToEnrichers(getName());
+                        getContext().getSummaryService().addToEnrichers(getName());
                         element.addToData(secretAnnotations);
                     }
                 } catch (IOException e) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/GitEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/GitEnricher.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import org.eclipse.jkube.kit.common.util.GitUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
 import org.eclipse.jkube.kit.config.resource.OpenShiftAnnotations;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -65,6 +66,7 @@ public class GitEnricher extends BaseEnricher {
                         log.warn("Could not detect any git remote");
                     }
 
+                    SummaryUtil.addToEnrichers(getName());
                     annotations.putAll(getAnnotations(platformMode, gitRemoteUrl, repository.getBranch(), GitUtil.getGitCommitId(repository), useDeprecatedAnnotationPrefix));
                 }
                 return annotations;

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/GitEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/GitEnricher.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import org.eclipse.jkube.kit.common.util.GitUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
 import org.eclipse.jkube.kit.config.resource.OpenShiftAnnotations;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -66,7 +65,7 @@ public class GitEnricher extends BaseEnricher {
                         log.warn("Could not detect any git remote");
                     }
 
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     annotations.putAll(getAnnotations(platformMode, gitRemoteUrl, repository.getBranch(), GitUtil.getGitCommitId(repository), useDeprecatedAnnotationPrefix));
                 }
                 return annotations;

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
@@ -40,7 +40,6 @@ import io.fabric8.openshift.api.model.DeploymentConfigFluent;
 import io.fabric8.openshift.api.model.DeploymentConfigSpecFluent;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.config.resource.ControllerResourceConfig;
@@ -206,7 +205,7 @@ public class ImageEnricher extends BaseEnricher {
                 if (containers == null) {
                     containers = new ArrayList<>();
                 }
-                SummaryUtil.addToEnrichers(getName());
+                getContext().getSummaryService().addToEnrichers(getName());
                 mergeImageConfigurationWithContainerSpec(containers);
                 podSpec.withContainers(containers).endSpec();
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
@@ -40,6 +40,7 @@ import io.fabric8.openshift.api.model.DeploymentConfigFluent;
 import io.fabric8.openshift.api.model.DeploymentConfigSpecFluent;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.config.resource.ControllerResourceConfig;
@@ -205,6 +206,7 @@ public class ImageEnricher extends BaseEnricher {
                 if (containers == null) {
                     containers = new ArrayList<>();
                 }
+                SummaryUtil.addToEnrichers(getName());
                 mergeImageConfigurationWithContainerSpec(containers);
                 podSpec.withContainers(containers).endSpec();
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImagePullPolicyEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImagePullPolicyEnricher.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
@@ -30,6 +31,7 @@ public class ImagePullPolicyEnricher extends BaseEnricher {
   public void enrich(PlatformMode platformMode, KubernetesListBuilder builder) {
     String imagePullPolicy = getValueFromConfig(JKUBE_ENFORCED_IMAGE_PULL_POLICY, null);
     if (StringUtils.isNotBlank(imagePullPolicy)) {
+      SummaryUtil.addToEnrichers(getName());
       builder.accept(new TypedVisitor<ContainerBuilder>() {
         @Override
         public void visit(ContainerBuilder containerBuilder) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImagePullPolicyEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImagePullPolicyEnricher.java
@@ -17,7 +17,6 @@ import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import org.apache.commons.lang3.StringUtils;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
@@ -31,7 +30,7 @@ public class ImagePullPolicyEnricher extends BaseEnricher {
   public void enrich(PlatformMode platformMode, KubernetesListBuilder builder) {
     String imagePullPolicy = getValueFromConfig(JKUBE_ENFORCED_IMAGE_PULL_POLICY, null);
     if (StringUtils.isNotBlank(imagePullPolicy)) {
-      SummaryUtil.addToEnrichers(getName());
+      getContext().getSummaryService().addToEnrichers(getName());
       builder.accept(new TypedVisitor<ContainerBuilder>() {
         @Override
         public void visit(ContainerBuilder containerBuilder) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
@@ -24,7 +24,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.enricher.generic.ingress.ExtensionsV1beta1IngressConverter;
 import org.eclipse.jkube.enricher.generic.ingress.NetworkingV1IngressGenerator;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.IngressConfig;
 import org.eclipse.jkube.kit.config.resource.IngressRuleConfig;
 import org.eclipse.jkube.kit.config.resource.IngressTlsConfig;
@@ -82,7 +81,7 @@ public class IngressEnricher extends BaseEnricher implements ServiceExposer {
                     }
                     HasMetadata generatedIngress = generateIngressWithConfiguredApiVersion(serviceBuilder);
                     if (generatedIngress != null) {
-                        SummaryUtil.addToEnrichers(getName());
+                        getContext().getSummaryService().addToEnrichers(getName());
                         listBuilder.addToItems(generatedIngress);
                     }
                 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/IngressEnricher.java
@@ -24,6 +24,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.enricher.generic.ingress.ExtensionsV1beta1IngressConverter;
 import org.eclipse.jkube.enricher.generic.ingress.NetworkingV1IngressGenerator;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.IngressConfig;
 import org.eclipse.jkube.kit.config.resource.IngressRuleConfig;
 import org.eclipse.jkube.kit.config.resource.IngressTlsConfig;
@@ -81,6 +82,7 @@ public class IngressEnricher extends BaseEnricher implements ServiceExposer {
                     }
                     HasMetadata generatedIngress = generateIngressWithConfiguredApiVersion(serviceBuilder);
                     if (generatedIngress != null) {
+                        SummaryUtil.addToEnrichers(getName());
                         listBuilder.addToItems(generatedIngress);
                     }
                 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/MavenIssueManagementEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/MavenIssueManagementEnricher.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -120,6 +121,7 @@ public class MavenIssueManagementEnricher extends BaseEnricher {
                 String system = rootProject.getIssueManagementSystem();
                 String url = rootProject.getIssueManagementUrl();
                 if (StringUtils.isNotEmpty(system) && StringUtils.isNotEmpty(url)) {
+                    SummaryUtil.addToEnrichers(getName());
                     annotations.put(JKubeAnnotations.ISSUE_SYSTEM.value(useDeprecatedAnnotationPrefix), system);
                     annotations.put(JKubeAnnotations.ISSUE_TRACKER_URL.value(useDeprecatedAnnotationPrefix), url);
                 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/MavenIssueManagementEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/MavenIssueManagementEnricher.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import org.eclipse.jkube.kit.common.JavaProject;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -121,7 +120,7 @@ public class MavenIssueManagementEnricher extends BaseEnricher {
                 String system = rootProject.getIssueManagementSystem();
                 String url = rootProject.getIssueManagementUrl();
                 if (StringUtils.isNotEmpty(system) && StringUtils.isNotEmpty(url)) {
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     annotations.put(JKubeAnnotations.ISSUE_SYSTEM.value(useDeprecatedAnnotationPrefix), system);
                     annotations.put(JKubeAnnotations.ISSUE_TRACKER_URL.value(useDeprecatedAnnotationPrefix), url);
                 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/MavenScmEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/MavenScmEnricher.java
@@ -24,7 +24,6 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import org.eclipse.jkube.kit.common.JavaProject;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -64,7 +63,7 @@ public class MavenScmEnricher extends BaseEnricher {
                 String url = rootProject.getScmUrl();
                 String tag = rootProject.getScmTag();
 
-                SummaryUtil.addToEnrichers(getName());
+                getContext().getSummaryService().addToEnrichers(getName());
                 if (StringUtils.isNotEmpty(tag)) {
                     annotations.put(JKubeAnnotations.SCM_TAG.value(useDeprecatedAnnotationPrefix), tag);
                 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/MavenScmEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/MavenScmEnricher.java
@@ -24,6 +24,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSetBuilder;
 import io.fabric8.kubernetes.api.model.batch.v1.JobBuilder;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.JKubeAnnotations;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -63,6 +64,7 @@ public class MavenScmEnricher extends BaseEnricher {
                 String url = rootProject.getScmUrl();
                 String tag = rootProject.getScmTag();
 
+                SummaryUtil.addToEnrichers(getName());
                 if (StringUtils.isNotEmpty(tag)) {
                     annotations.put(JKubeAnnotations.SCM_TAG.value(useDeprecatedAnnotationPrefix), tag);
                 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/NameEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/NameEnricher.java
@@ -15,7 +15,6 @@ package org.eclipse.jkube.enricher.generic;
 
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -51,7 +50,7 @@ public class NameEnricher extends BaseEnricher {
   public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
     final String configuredName = getConfig(Config.NAME);
     final String defaultName = JKubeProjectUtil.createDefaultResourceName(getContext().getGav().getSanitizedArtifactId());
-    SummaryUtil.addToEnrichers(getName());
+    getContext().getSummaryService().addToEnrichers(getName());
     builder.accept(new TypedVisitor<ObjectMetaBuilder>() {
       @Override
       public void visit(ObjectMetaBuilder resource) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/NameEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/NameEnricher.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.enricher.generic;
 
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -50,6 +51,7 @@ public class NameEnricher extends BaseEnricher {
   public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
     final String configuredName = getConfig(Config.NAME);
     final String defaultName = JKubeProjectUtil.createDefaultResourceName(getContext().getGav().getSanitizedArtifactId());
+    SummaryUtil.addToEnrichers(getName());
     builder.accept(new TypedVisitor<ObjectMetaBuilder>() {
       @Override
       public void visit(ObjectMetaBuilder resource) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/PodAnnotationEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/PodAnnotationEnricher.java
@@ -18,7 +18,6 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import org.eclipse.jkube.kit.common.util.MapUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
@@ -48,7 +47,7 @@ public class PodAnnotationEnricher extends BaseEnricher {
                         template.setMetadata(new ObjectMeta());
                     }
                     final ObjectMeta templateMetadata = template.getMetadata();
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     templateMetadata.setAnnotations(MapUtil.mergeMaps(templateMetadata.getAnnotations(), item.getMetadata().getAnnotations()));
                 }
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/PodAnnotationEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/PodAnnotationEnricher.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.PodTemplateSpec;
 import org.eclipse.jkube.kit.common.util.MapUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
@@ -47,6 +48,7 @@ public class PodAnnotationEnricher extends BaseEnricher {
                         template.setMetadata(new ObjectMeta());
                     }
                     final ObjectMeta templateMetadata = template.getMetadata();
+                    SummaryUtil.addToEnrichers(getName());
                     templateMetadata.setAnnotations(MapUtil.mergeMaps(templateMetadata.getAnnotations(), item.getMetadata().getAnnotations()));
                 }
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/PortNameEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/PortNameEnricher.java
@@ -16,7 +16,6 @@ package org.eclipse.jkube.enricher.generic;
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -57,7 +56,7 @@ public class PortNameEnricher extends BaseEnricher {
 
                 // If port is given but no name, then try to detect the name
                 if (port != null && StringUtils.isBlank(portBuilder.getName())) {
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     addPortName(portBuilder, port);
                 }
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/PortNameEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/PortNameEnricher.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.enricher.generic;
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -56,6 +57,7 @@ public class PortNameEnricher extends BaseEnricher {
 
                 // If port is given but no name, then try to detect the name
                 if (port != null && StringUtils.isBlank(portBuilder.getName())) {
+                    SummaryUtil.addToEnrichers(getName());
                     addPortName(portBuilder, port);
                 }
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.MapUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -84,7 +83,7 @@ public class ProjectLabelEnricher extends BaseEnricher {
 
     @Override
     public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
-        SummaryUtil.addToEnrichers(getName());
+        getContext().getSummaryService().addToEnrichers(getName());
         builder.accept(new TypedVisitor<ServiceBuilder>() {
             @Override
             public void visit(ServiceBuilder serviceBuilder) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ProjectLabelEnricher.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.MapUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.GroupArtifactVersion;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -83,6 +84,7 @@ public class ProjectLabelEnricher extends BaseEnricher {
 
     @Override
     public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
+        SummaryUtil.addToEnrichers(getName());
         builder.accept(new TypedVisitor<ServiceBuilder>() {
             @Override
             public void visit(ServiceBuilder serviceBuilder) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ReplicaCountEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ReplicaCountEnricher.java
@@ -14,7 +14,6 @@
 package org.eclipse.jkube.enricher.generic;
 
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
@@ -35,7 +34,7 @@ public class ReplicaCountEnricher extends BaseEnricher {
   public void enrich(PlatformMode platformMode, KubernetesListBuilder builder) {
     Integer replicas = Configs.asInteger(getValueFromConfig(JKUBE_ENFORCED_REPLICAS, null));
     if (replicas != null) {
-      SummaryUtil.addToEnrichers(getName());
+      getContext().getSummaryService().addToEnrichers(getName());
       getContext().getHandlerHub().getControllerHandlers()
           .forEach(controller -> controller.get().overrideReplicas(builder, replicas));
     }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ReplicaCountEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ReplicaCountEnricher.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.enricher.generic;
 
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
@@ -34,6 +35,7 @@ public class ReplicaCountEnricher extends BaseEnricher {
   public void enrich(PlatformMode platformMode, KubernetesListBuilder builder) {
     Integer replicas = Configs.asInteger(getValueFromConfig(JKUBE_ENFORCED_REPLICAS, null));
     if (replicas != null) {
+      SummaryUtil.addToEnrichers(getName());
       getContext().getHandlerHub().getControllerHandlers()
           .forEach(controller -> controller.get().overrideReplicas(builder, replicas));
     }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/RevisionHistoryEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/RevisionHistoryEnricher.java
@@ -19,7 +19,6 @@ import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -55,7 +54,7 @@ public class RevisionHistoryEnricher extends BaseEnricher {
 
         log.info("Adding revision history limit to %s", maxRevisionHistories);
 
-        SummaryUtil.addToEnrichers(getName());
+        getContext().getSummaryService().addToEnrichers(getName());
         builder.accept(new TypedVisitor<io.fabric8.kubernetes.api.model.apps.DeploymentBuilder>() {
             @Override
             public void visit(io.fabric8.kubernetes.api.model.apps.DeploymentBuilder item) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/RevisionHistoryEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/RevisionHistoryEnricher.java
@@ -19,6 +19,7 @@ import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -54,6 +55,7 @@ public class RevisionHistoryEnricher extends BaseEnricher {
 
         log.info("Adding revision history limit to %s", maxRevisionHistories);
 
+        SummaryUtil.addToEnrichers(getName());
         builder.accept(new TypedVisitor<io.fabric8.kubernetes.api.model.apps.DeploymentBuilder>() {
             @Override
             public void visit(io.fabric8.kubernetes.api.model.apps.DeploymentBuilder item) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/SecretEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/SecretEnricher.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import org.eclipse.jkube.kit.common.util.Base64Util;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.resource.SecretConfig;
@@ -65,7 +64,7 @@ public abstract class SecretEnricher extends BaseEnricher {
                     }
                     // remove the annotation key
                     annotation.remove(getAnnotationKey());
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     secretBuilder.addToData(data);
                 }
             }
@@ -124,7 +123,7 @@ public abstract class SecretEnricher extends BaseEnricher {
 
             Secret secret = new SecretBuilder().withData(data).withMetadata(metadata).withType(type).build();
             if(!secretToIndexMap.containsKey(secretConfig.getName())) {
-                SummaryUtil.addToEnrichers(getName());
+                getContext().getSummaryService().addToEnrichers(getName());
                 builder.addToSecretItems(i, secret);
             }
         }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/SecretEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/SecretEnricher.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.api.model.SecretBuilder;
 import org.eclipse.jkube.kit.common.util.Base64Util;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.resource.SecretConfig;
@@ -64,6 +65,7 @@ public abstract class SecretEnricher extends BaseEnricher {
                     }
                     // remove the annotation key
                     annotation.remove(getAnnotationKey());
+                    SummaryUtil.addToEnrichers(getName());
                     secretBuilder.addToData(data);
                 }
             }
@@ -122,6 +124,7 @@ public abstract class SecretEnricher extends BaseEnricher {
 
             Secret secret = new SecretBuilder().withData(data).withMetadata(metadata).withType(type).build();
             if(!secretToIndexMap.containsKey(secretConfig.getName())) {
+                SummaryUtil.addToEnrichers(getName());
                 builder.addToSecretItems(i, secret);
             }
         }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ServiceAccountEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ServiceAccountEnricher.java
@@ -22,7 +22,6 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.resource.ServiceAccountConfig;
@@ -69,7 +68,7 @@ public class ServiceAccountEnricher extends BaseEnricher {
     private List<ServiceAccount> createServiceAccountFromResourceConfig(ResourceConfig resourceConfig) {
         List<ServiceAccount> serviceAccounts = new ArrayList<>();
         if(resourceConfig != null && resourceConfig.getServiceAccounts() != null && !Boolean.parseBoolean(getConfig(Config.SKIP_CREATE))) {
-            SummaryUtil.addToEnrichers(getName());
+            getContext().getSummaryService().addToEnrichers(getName());
             for(ServiceAccountConfig serviceAccountConfig : resourceConfig.getServiceAccounts()) {
                 if(serviceAccountConfig.getName() != null) {
                     serviceAccounts.add(createServiceAccount(serviceAccountConfig.getName()));
@@ -90,7 +89,7 @@ public class ServiceAccountEnricher extends BaseEnricher {
                     serviceAccounts.add(createServiceAccount(serviceAccountName));
                 }
                 if(deploymentToSaPair.containsKey(deploymentBuilder.buildMetadata().getName())) {
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     deploymentBuilder.editSpec()
                         .editTemplate()
                         .editSpec()

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ServiceAccountEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ServiceAccountEnricher.java
@@ -22,6 +22,7 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.resource.ServiceAccountConfig;
@@ -68,6 +69,7 @@ public class ServiceAccountEnricher extends BaseEnricher {
     private List<ServiceAccount> createServiceAccountFromResourceConfig(ResourceConfig resourceConfig) {
         List<ServiceAccount> serviceAccounts = new ArrayList<>();
         if(resourceConfig != null && resourceConfig.getServiceAccounts() != null && !Boolean.parseBoolean(getConfig(Config.SKIP_CREATE))) {
+            SummaryUtil.addToEnrichers(getName());
             for(ServiceAccountConfig serviceAccountConfig : resourceConfig.getServiceAccounts()) {
                 if(serviceAccountConfig.getName() != null) {
                     serviceAccounts.add(createServiceAccount(serviceAccountConfig.getName()));
@@ -88,6 +90,7 @@ public class ServiceAccountEnricher extends BaseEnricher {
                     serviceAccounts.add(createServiceAccount(serviceAccountName));
                 }
                 if(deploymentToSaPair.containsKey(deploymentBuilder.buildMetadata().getName())) {
+                    SummaryUtil.addToEnrichers(getName());
                     deploymentBuilder.editSpec()
                         .editTemplate()
                         .editSpec()

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/TriggersAnnotationEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/TriggersAnnotationEnricher.java
@@ -34,7 +34,6 @@ import io.fabric8.openshift.api.model.ImageChangeTriggerBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -147,7 +146,7 @@ public class TriggersAnnotationEnricher extends BaseEnricher {
                             .build();
 
                     trigger.setAdditionalProperty("fieldPath", "spec.template.spec.containers[?(@.name==\"" + containerName + "\")].image");
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     triggerList.add(trigger);
                 }
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/TriggersAnnotationEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/TriggersAnnotationEnricher.java
@@ -34,6 +34,7 @@ import io.fabric8.openshift.api.model.ImageChangeTriggerBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -146,6 +147,7 @@ public class TriggersAnnotationEnricher extends BaseEnricher {
                             .build();
 
                     trigger.setAdditionalProperty("fieldPath", "spec.template.spec.containers[?(@.name==\"" + containerName + "\")].image");
+                    SummaryUtil.addToEnrichers(getName());
                     triggerList.add(trigger);
                 }
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/VolumePermissionEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/VolumePermissionEnricher.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -96,6 +97,7 @@ public class VolumePermissionEnricher extends BaseEnricher {
 
                 log.verbose("Adding init container for changing persistent volumes access mode to %s",
                         getConfig(Config.PERMISSION));
+                SummaryUtil.addToEnrichers(getName());
                 if (!KubernetesResourceUtil.hasInitContainer(builder, ENRICHER_NAME)) {
                     KubernetesResourceUtil.appendInitContainer(builder, createPvInitContainer(podSpec), log);
                 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/VolumePermissionEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/VolumePermissionEnricher.java
@@ -31,7 +31,6 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -97,7 +96,7 @@ public class VolumePermissionEnricher extends BaseEnricher {
 
                 log.verbose("Adding init container for changing persistent volumes access mode to %s",
                         getConfig(Config.PERMISSION));
-                SummaryUtil.addToEnrichers(getName());
+                getContext().getSummaryService().addToEnrichers(getName());
                 if (!KubernetesResourceUtil.hasInitContainer(builder, ENRICHER_NAME)) {
                     KubernetesResourceUtil.appendInitContainer(builder, createPvInitContainer(podSpec), log);
                 }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/AutoTLSEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/AutoTLSEnricher.java
@@ -26,7 +26,6 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -81,7 +80,7 @@ public class AutoTLSEnricher extends BaseEnricher {
             return;
         }
 
-        SummaryUtil.addToEnrichers(getName());
+        getContext().getSummaryService().addToEnrichers(getName());
         builder.accept(new TypedVisitor<PodTemplateSpecBuilder>() {
             @Override
             public void visit(PodTemplateSpecBuilder builder) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/AutoTLSEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/AutoTLSEnricher.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -80,6 +81,7 @@ public class AutoTLSEnricher extends BaseEnricher {
             return;
         }
 
+        SummaryUtil.addToEnrichers(getName());
         builder.accept(new TypedVisitor<PodTemplateSpecBuilder>() {
             @Override
             public void visit(PodTemplateSpecBuilder builder) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/DeploymentConfigEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/DeploymentConfigEnricher.java
@@ -27,6 +27,7 @@ import io.fabric8.openshift.api.model.DeploymentConfigSpecBuilder;
 import io.fabric8.openshift.api.model.DeploymentStrategy;
 import io.fabric8.openshift.api.model.DeploymentStrategyBuilder;
 import org.eclipse.jkube.enricher.generic.DefaultControllerEnricher;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.EnricherConfig;
@@ -51,6 +52,7 @@ public class DeploymentConfigEnricher extends BaseEnricher {
     public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
         if (isApplicable(platformMode)) {
             for(HasMetadata item : builder.buildItems()) {
+                SummaryUtil.addToEnrichers(getName());
                 if(item instanceof Deployment) {
                     DeploymentConfig deploymentConfig = convertFromAppsV1Deployment(item);
                     removeItemFromKubernetesBuilder(builder, item);

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/DeploymentConfigEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/DeploymentConfigEnricher.java
@@ -27,7 +27,6 @@ import io.fabric8.openshift.api.model.DeploymentConfigSpecBuilder;
 import io.fabric8.openshift.api.model.DeploymentStrategy;
 import io.fabric8.openshift.api.model.DeploymentStrategyBuilder;
 import org.eclipse.jkube.enricher.generic.DefaultControllerEnricher;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.EnricherConfig;
@@ -52,7 +51,7 @@ public class DeploymentConfigEnricher extends BaseEnricher {
     public void create(PlatformMode platformMode, KubernetesListBuilder builder) {
         if (isApplicable(platformMode)) {
             for(HasMetadata item : builder.buildItems()) {
-                SummaryUtil.addToEnrichers(getName());
+                getContext().getSummaryService().addToEnrichers(getName());
                 if(item instanceof Deployment) {
                     DeploymentConfig deploymentConfig = convertFromAppsV1Deployment(item);
                     removeItemFromKubernetesBuilder(builder, item);

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ImageChangeTriggerEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ImageChangeTriggerEnricher.java
@@ -22,6 +22,7 @@ import io.fabric8.openshift.api.model.DeploymentConfigSpecBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -63,6 +64,7 @@ public class ImageChangeTriggerEnricher extends BaseEnricher {
         if(platformMode.equals(PlatformMode.kubernetes))
             return;
 
+        SummaryUtil.addToEnrichers(getName());
         builder.accept(new TypedVisitor<DeploymentConfigSpecBuilder>() {
             @Override
             public void visit(DeploymentConfigSpecBuilder builder) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ImageChangeTriggerEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ImageChangeTriggerEnricher.java
@@ -22,7 +22,6 @@ import io.fabric8.openshift.api.model.DeploymentConfigSpecBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageName;
 import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -64,7 +63,7 @@ public class ImageChangeTriggerEnricher extends BaseEnricher {
         if(platformMode.equals(PlatformMode.kubernetes))
             return;
 
-        SummaryUtil.addToEnrichers(getName());
+        getContext().getSummaryService().addToEnrichers(getName());
         builder.accept(new TypedVisitor<DeploymentConfigSpecBuilder>() {
             @Override
             public void visit(DeploymentConfigSpecBuilder builder) {

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ProjectEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ProjectEnricher.java
@@ -22,7 +22,6 @@ import io.fabric8.openshift.api.model.ProjectBuilder;
 import io.fabric8.openshift.api.model.ProjectSpec;
 import io.fabric8.openshift.api.model.ProjectStatus;
 import io.fabric8.openshift.api.model.ProjectStatusBuilder;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -44,7 +43,7 @@ public class ProjectEnricher extends BaseEnricher {
                 if(item instanceof Namespace) {
                     Project project = convertToProject((Namespace) item);
                     removeItemFromKubernetesBuilder(builder, item);
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     builder.addToItems(project);
                 }
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ProjectEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/ProjectEnricher.java
@@ -22,6 +22,7 @@ import io.fabric8.openshift.api.model.ProjectBuilder;
 import io.fabric8.openshift.api.model.ProjectSpec;
 import io.fabric8.openshift.api.model.ProjectStatus;
 import io.fabric8.openshift.api.model.ProjectStatusBuilder;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -43,6 +44,7 @@ public class ProjectEnricher extends BaseEnricher {
                 if(item instanceof Namespace) {
                     Project project = convertToProject((Namespace) item);
                     removeItemFromKubernetesBuilder(builder, item);
+                    SummaryUtil.addToEnrichers(getName());
                     builder.addToItems(project);
                 }
             }

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
@@ -17,7 +17,6 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.openshift.api.model.RouteSpec;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.FileUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -82,7 +81,7 @@ public class RouteEnricher extends BaseEnricher implements ServiceExposer {
         }
 
         if(platformMode == PlatformMode.openshift && isGenerateRoute()) {
-            SummaryUtil.addToEnrichers(getName());
+            getContext().getSummaryService().addToEnrichers(getName());
             listBuilder.accept(new TypedVisitor<ServiceBuilder>() {
 
                 @Override

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricher.java
@@ -17,6 +17,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.openshift.api.model.RouteSpec;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.FileUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
@@ -81,6 +82,7 @@ public class RouteEnricher extends BaseEnricher implements ServiceExposer {
         }
 
         if(platformMode == PlatformMode.openshift && isGenerateRoute()) {
+            SummaryUtil.addToEnrichers(getName());
             listBuilder.accept(new TypedVisitor<ServiceBuilder>() {
 
                 @Override

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricherCreateTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricherCreateTest.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.apps.StatefulSet;
 import io.fabric8.kubernetes.api.model.batch.v1.Job;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
@@ -34,6 +35,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.File;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -49,8 +51,10 @@ class DefaultControllerEnricherCreateTest {
   @BeforeEach
   void setUp() throws Exception {
     properties = new Properties();
+    SummaryService summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
     buildContext = JKubeEnricherContext.builder()
         .log(new KitLogger.SilentLogger())
+        .summaryService(summaryService)
         .resources(ResourceConfig.builder().build())
         .image(ImageConfiguration.builder().build())
         .project(JavaProject.builder()

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultControllerEnricherTest.java
@@ -21,6 +21,7 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentSpec;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.common.JavaProject;
@@ -31,6 +32,7 @@ import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -51,9 +53,11 @@ class DefaultControllerEnricherTest {
     void setUp() throws Exception {
         config = new HashMap<>();
         properties = new Properties();
+        SummaryService summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
         context = JKubeEnricherContext.builder()
             .processorConfig(new ProcessorConfig(null, null, config))
             .log(new KitLogger.SilentLogger())
+            .summaryService(summaryService)
             .image(ImageConfiguration.builder()
                 .name("helloworld")
                 .build(BuildConfiguration.builder()

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultNamespaceEnricherTest.java
@@ -17,6 +17,7 @@ import java.util.Properties;
 
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
@@ -34,14 +35,17 @@ import io.fabric8.openshift.api.model.ProjectBuilder;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class DefaultNamespaceEnricherTest {
 
   private EnricherContext context;
 
   private void setExpectations(Properties properties, ResourceConfig resourceConfig) {
+    SummaryService summaryService = mock(SummaryService.class);
     context = JKubeEnricherContext.builder()
         .log(new KitLogger.SilentLogger())
+        .summaryService(summaryService)
         .resources(resourceConfig)
         .project(JavaProject.builder()
             .properties(properties)

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.enricher.generic;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.Properties;
 
@@ -20,6 +21,7 @@ import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -40,6 +42,7 @@ class DefaultServiceEnricherAddMissingPartsTest {
   @BeforeEach
   void setUp() {
     properties = new Properties();
+    KitLogger logger = new KitLogger.SilentLogger();
     final JKubeEnricherContext context = JKubeEnricherContext.builder()
       .image(ImageConfiguration.builder()
         .name("test-image")
@@ -50,7 +53,8 @@ class DefaultServiceEnricherAddMissingPartsTest {
         .groupId("group-id")
         .artifactId("artifact-id")
         .build())
-      .log(new KitLogger.SilentLogger())
+      .log(logger)
+      .summaryService(new SummaryService(new File("target"), logger, false))
       .build();
     enricher = new DefaultServiceEnricher(context);
   }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherExternalServiceTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherExternalServiceTest.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -34,6 +35,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -44,6 +46,7 @@ class DefaultServiceEnricherExternalServiceTest {
 
   @BeforeEach
   void setUp() {
+    KitLogger kitLogger = new KitLogger.SilentLogger();
     final JKubeEnricherContext context = JKubeEnricherContext.builder()
       .image(ImageConfiguration.builder()
         .name("test-image")
@@ -57,7 +60,8 @@ class DefaultServiceEnricherExternalServiceTest {
         .groupId("group-id")
         .artifactId("artifact-id")
         .build())
-      .log(new KitLogger.SilentLogger())
+      .log(kitLogger)
+      .summaryService(new SummaryService(new File("target"), kitLogger, false))
       .build();
     kubernetesListBuilder = new KubernetesListBuilder();
     kubernetesListBuilder.addToItems(createNewExternalServiceFragment());

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DependencyEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DependencyEnricherTest.java
@@ -19,6 +19,7 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.Dependency;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.api.model.KindAndName;
@@ -48,6 +49,7 @@ class DependencyEnricherTest {
 
     @BeforeEach
     void setUp() {
+        KitLogger logger = new KitLogger.SilentLogger();
         context = JKubeEnricherContext.builder()
           .project(JavaProject.builder()
             .name("the-project")
@@ -57,7 +59,8 @@ class DependencyEnricherTest {
               .file(new File(getClass().getResource(ARTIFACT_FILE_PATH).getFile()))
               .build()))
             .build())
-          .log(new KitLogger.SilentLogger())
+          .log(logger)
+          .summaryService(new SummaryService(new File("target"), logger, false))
           .build();
     }
 

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DockerRegistrySecretEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DockerRegistrySecretEnricherTest.java
@@ -23,6 +23,7 @@ import io.fabric8.kubernetes.api.model.SecretBuilder;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.RegistryServerConfiguration;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.api.util.SecretConstants;
@@ -30,6 +31,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -45,9 +47,11 @@ class DockerRegistrySecretEnricherTest {
 
     @BeforeEach
     void setupExpectations() {
+        KitLogger kitLogger = new KitLogger.SilentLogger();
         context = JKubeEnricherContext.builder()
-          .log(new KitLogger.SilentLogger())
+          .log(kitLogger)
           .project(JavaProject.builder().build())
+          .summaryService(new SummaryService(new File("target"), kitLogger, false))
           .setting(RegistryServerConfiguration.builder()
             .configuration(new HashMap<>())
             .id("docker.io")

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ImagePullPolicyEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ImagePullPolicyEnricherTest.java
@@ -13,7 +13,6 @@
  */
 package org.eclipse.jkube.enricher.generic;
 
-
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
@@ -42,10 +41,12 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ObjectAssert;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.List;
 import java.util.Properties;
 
@@ -317,7 +318,9 @@ class ImagePullPolicyEnricherTest {
   }
 
   private JKubeEnricherContext createNewJKubeEnricherContextWithProperties(Properties properties) {
+    SummaryService summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
     return JKubeEnricherContext.builder()
+        .summaryService(summaryService)
         .log(new KitLogger.SilentLogger())
         .project(JavaProject.builder()
             .properties(properties)

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/IngressEnricherBehavioralTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/IngressEnricherBehavioralTest.java
@@ -19,12 +19,14 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.networking.v1.IngressBuilder;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,11 +38,13 @@ class IngressEnricherBehavioralTest {
 
   @BeforeEach
   void setUp() throws Exception {
+    SummaryService summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
     context = JKubeEnricherContext.builder()
       .project(JavaProject.builder()
         .properties(new Properties())
         .build())
       .resources(ResourceConfig.builder().build())
+      .summaryService(summaryService)
       .log(new KitLogger.SilentLogger())
       .build();
     klb = new KubernetesListBuilder();

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/PodAnnotationEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/PodAnnotationEnricherTest.java
@@ -26,6 +26,8 @@ import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigBuilder;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -35,6 +37,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.io.File;
 import java.util.Properties;
 import java.util.stream.Stream;
 
@@ -49,10 +52,12 @@ class PodAnnotationEnricherTest {
   void setUp() {
     Properties properties = new Properties();
     klb = new KubernetesListBuilder();
+    SummaryService summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
     EnricherContext context = JKubeEnricherContext.builder()
         .project(JavaProject.builder()
             .properties(properties)
             .build())
+        .summaryService(summaryService)
         .build();
     podAnnotationEnricher = new PodAnnotationEnricher(context);
   }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ReplicaCountEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ReplicaCountEnricherTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.enricher.generic;
 
 import java.util.Collections;
+import java.io.File;
 import java.util.List;
 import java.util.Properties;
 
@@ -26,6 +27,7 @@ import io.fabric8.openshift.api.model.DeploymentConfig;
 import io.fabric8.openshift.api.model.DeploymentConfigSpec;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.enricher.api.EnricherContext;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,11 +54,13 @@ class ReplicaCountEnricherTest {
     void setUpEnricher() {
         final Properties properties = new Properties();
         properties.setProperty("jkube.replicas", "" + EXPECTED_REPLICAS);
+        SummaryService summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
         EnricherContext context = JKubeEnricherContext.builder()
             .log(new KitLogger.SilentLogger())
             .project(JavaProject.builder()
                 .properties(properties)
                 .build())
+            .summaryService(summaryService)
             .build();
         enricher = new ReplicaCountEnricher(context);
     }

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ServiceAccountEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/ServiceAccountEnricherTest.java
@@ -20,6 +20,8 @@ import io.fabric8.kubernetes.api.model.apps.Deployment;
 import io.fabric8.kubernetes.api.model.apps.DeploymentBuilder;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.resource.ServiceAccountConfig;
@@ -27,6 +29,7 @@ import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +44,7 @@ class ServiceAccountEnricherTest {
             .properties(new Properties())
             .build())
           .resources(ResourceConfig.builder().build())
+          .summaryService(new SummaryService(new File("target"), new KitLogger.SilentLogger(), false))
           .build();
     }
 

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/DeploymentConfigEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/DeploymentConfigEnricherTest.java
@@ -13,11 +13,13 @@
  */
 package org.eclipse.jkube.enricher.generic.openshift;
 
+import java.io.File;
 import java.util.Properties;
 import java.util.function.Consumer;
 
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 
@@ -38,11 +40,13 @@ class DeploymentConfigEnricherTest {
 
   @BeforeEach
   void setUp() {
+    KitLogger logger = new KitLogger.SilentLogger();
     context = JKubeEnricherContext.builder()
-      .log(new KitLogger.SilentLogger())
+      .log(logger)
       .project(JavaProject.builder()
         .properties(new Properties())
         .build())
+      .summaryService(new SummaryService(new File("target"), logger, false))
       .build();
     deploymentConfigEnricher = new DeploymentConfigEnricher(context);
     kubernetesListBuilder = new KubernetesListBuilder();

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/ProjectEnricherTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/ProjectEnricherTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.mock;
 
 class ProjectEnricherTest {
@@ -34,7 +35,7 @@ class ProjectEnricherTest {
 
     @BeforeEach
     void setExpectations() {
-      context = mock(JKubeEnricherContext.class);
+        context = mock(JKubeEnricherContext.class, RETURNS_DEEP_STUBS);
     }
 
     @Test

--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricherBehavioralTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/openshift/RouteEnricherBehavioralTest.java
@@ -18,12 +18,14 @@ import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -35,12 +37,14 @@ class RouteEnricherBehavioralTest {
 
   @BeforeEach
   void setUp() {
+    SummaryService summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
     context = JKubeEnricherContext.builder()
       .project(JavaProject.builder()
         .properties(new Properties())
         .build())
       .resources(ResourceConfig.builder().build())
       .log(new KitLogger.SilentLogger())
+      .summaryService(summaryService)
       .build();
     klb = new KubernetesListBuilder();
   }

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/DockerHealthCheckEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/DockerHealthCheckEnricher.java
@@ -18,7 +18,6 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ExecAction;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.HealthCheckConfiguration;
 import org.eclipse.jkube.kit.config.image.build.HealthCheckMode;
@@ -60,7 +59,7 @@ public class DockerHealthCheckEnricher extends AbstractHealthCheckEnricher {
     private Probe getProbe(ImageConfiguration image) {
         if (hasHealthCheck(image)) {
             HealthCheckConfiguration health = image.getBuildConfiguration().getHealthCheck();
-            SummaryUtil.addToEnrichers(getName());
+            getContext().getSummaryService().addToEnrichers(getName());
             return new ProbeBuilder()
                     .withExec(new ExecAction(health.getCmd().asStrings()))
                     .withTimeoutSeconds(durationSeconds(health.getTimeout()).orElse(null))

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/DockerHealthCheckEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/DockerHealthCheckEnricher.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ExecAction;
 import io.fabric8.kubernetes.api.model.Probe;
 import io.fabric8.kubernetes.api.model.ProbeBuilder;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.HealthCheckConfiguration;
 import org.eclipse.jkube.kit.config.image.build.HealthCheckMode;
@@ -59,6 +60,7 @@ public class DockerHealthCheckEnricher extends AbstractHealthCheckEnricher {
     private Probe getProbe(ImageConfiguration image) {
         if (hasHealthCheck(image)) {
             HealthCheckConfiguration health = image.getBuildConfiguration().getHealthCheck();
+            SummaryUtil.addToEnrichers(getName());
             return new ProbeBuilder()
                     .withExec(new ExecAction(health.getCmd().asStrings()))
                     .withTimeoutSeconds(durationSeconds(health.getTimeout()).orElse(null))

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/KarafHealthCheckEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/KarafHealthCheckEnricher.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 
 import java.util.List;
@@ -91,6 +92,7 @@ public class KarafHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
                 for (String featureValue : features) {
                     if ("jkube-karaf-checks".equals(featureValue)) {
+                        SummaryUtil.addToEnrichers(getName());
                         return new ProbeBuilder().withNewHttpGet().withNewPort(DEFAULT_HEALTH_CHECK_PORT).withPath(path).endHttpGet()
                                 .withSuccessThreshold(getSuccessThreshold())
                                 .withFailureThreshold(getFailureThreshold())
@@ -101,6 +103,7 @@ public class KarafHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
                 String featureValue = (String) feature;
                 if ("jkube-karaf-checks".equals(featureValue)) {
+                    SummaryUtil.addToEnrichers(getName());
                     return new ProbeBuilder().withNewHttpGet().withNewPort(DEFAULT_HEALTH_CHECK_PORT).withPath(path).endHttpGet()
                             .withSuccessThreshold(getSuccessThreshold())
                             .withFailureThreshold(getFailureThreshold())

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/KarafHealthCheckEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/KarafHealthCheckEnricher.java
@@ -18,7 +18,6 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 
 import java.util.List;
@@ -92,7 +91,7 @@ public class KarafHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
                 for (String featureValue : features) {
                     if ("jkube-karaf-checks".equals(featureValue)) {
-                        SummaryUtil.addToEnrichers(getName());
+                        getContext().getSummaryService().addToEnrichers(getName());
                         return new ProbeBuilder().withNewHttpGet().withNewPort(DEFAULT_HEALTH_CHECK_PORT).withPath(path).endHttpGet()
                                 .withSuccessThreshold(getSuccessThreshold())
                                 .withFailureThreshold(getFailureThreshold())
@@ -103,7 +102,7 @@ public class KarafHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
                 String featureValue = (String) feature;
                 if ("jkube-karaf-checks".equals(featureValue)) {
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     return new ProbeBuilder().withNewHttpGet().withNewPort(DEFAULT_HEALTH_CHECK_PORT).withPath(path).endHttpGet()
                             .withSuccessThreshold(getSuccessThreshold())
                             .withFailureThreshold(getFailureThreshold())

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/PrometheusEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/PrometheusEnricher.java
@@ -19,7 +19,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -68,7 +67,7 @@ public class PrometheusEnricher extends BaseEnricher {
                     annotations.put(ANNOTATION_PROMETHEUS_PORT, prometheusPort);
                     annotations.put(ANNOTATION_PROMETHEUS_SCRAPE, "true");
                     annotations.put(ANNOTATION_PROMETHEUS_PATH, getConfig(Config.PROMETHEUS_PATH));
-                    SummaryUtil.addToEnrichers(getName());
+                    getContext().getSummaryService().addToEnrichers(getName());
                     log.verbose("Adding prometheus.io annotations: %s",
                             annotations.entrySet()
                                     .stream()

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/PrometheusEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/PrometheusEnricher.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -67,6 +68,7 @@ public class PrometheusEnricher extends BaseEnricher {
                     annotations.put(ANNOTATION_PROMETHEUS_PORT, prometheusPort);
                     annotations.put(ANNOTATION_PROMETHEUS_SCRAPE, "true");
                     annotations.put(ANNOTATION_PROMETHEUS_PATH, getConfig(Config.PROMETHEUS_PATH));
+                    SummaryUtil.addToEnrichers(getName());
                     log.verbose("Adding prometheus.io annotations: %s",
                             annotations.entrySet()
                                     .stream()

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricher.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -138,7 +137,7 @@ public class ServiceDiscoveryEnricher extends BaseEnricher {
                 annotations.put(PREFIX + "/" + ANNOTATION_DESCRIPTION_PATH, resolvedDescriptionPath);
             }
             annotations.forEach((key, value) -> log.info("Add %s annotation: \"%s\" : \"%s\"", PREFIX, key, value));
-            SummaryUtil.addToEnrichers(getName());
+            getContext().getSummaryService().addToEnrichers(getName());
             serviceBuilder.editMetadata().addToAnnotations(annotations).and().buildMetadata();
         }
     }

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/ServiceDiscoveryEnricher.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.ServicePort;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.BaseEnricher;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -137,6 +138,7 @@ public class ServiceDiscoveryEnricher extends BaseEnricher {
                 annotations.put(PREFIX + "/" + ANNOTATION_DESCRIPTION_PATH, resolvedDescriptionPath);
             }
             annotations.forEach((key, value) -> log.info("Add %s annotation: \"%s\" : \"%s\"", PREFIX, key, value));
+            SummaryUtil.addToEnrichers(getName());
             serviceBuilder.editMetadata().addToAnnotations(annotations).and().buildMetadata();
         }
     }

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/WebAppHealthCheckEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/WebAppHealthCheckEnricher.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.apache.commons.lang3.StringUtils;
 
@@ -62,6 +63,7 @@ public class WebAppHealthCheckEnricher extends AbstractHealthCheckEnricher {
             return null;
         }
 
+        SummaryUtil.addToEnrichers(getName());
         Integer port = getPort();
         String scheme = getScheme().toUpperCase();
         String path = getPath();

--- a/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/WebAppHealthCheckEnricher.java
+++ b/jkube-kit/enricher/specific/src/main/java/org/eclipse/jkube/kit/enricher/specific/WebAppHealthCheckEnricher.java
@@ -18,7 +18,6 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.apache.commons.lang3.StringUtils;
 
@@ -63,7 +62,7 @@ public class WebAppHealthCheckEnricher extends AbstractHealthCheckEnricher {
             return null;
         }
 
-        SummaryUtil.addToEnrichers(getName());
+        getContext().getSummaryService().addToEnrichers(getName());
         Integer port = getPort();
         String scheme = getScheme().toUpperCase();
         String path = getPath();

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/GeneratorManager.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/GeneratorManager.java
@@ -16,9 +16,9 @@ package org.eclipse.jkube.generator.api;
 import java.util.List;
 
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.ClassUtil;
 import org.eclipse.jkube.kit.common.util.PluginServiceFactory;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 
 /**
@@ -37,7 +37,7 @@ public class GeneratorManager {
   }
 
   public static List<ImageConfiguration> generate(List<ImageConfiguration> imageConfigs,
-      GeneratorContext genCtx, boolean prePackagePhase) {
+                                                  GeneratorContext genCtx, boolean prePackagePhase, SummaryService summaryService) {
 
     final PluginServiceFactory<GeneratorContext> pluginFactory = new PluginServiceFactory<>(genCtx);
     if (genCtx.isUseProjectClasspath()) {
@@ -54,7 +54,7 @@ public class GeneratorManager {
       log.verbose(" - %s", generator.getName());
       if (generator.isApplicable(ret)) {
         log.info("Running generator %s", generator.getName());
-        SummaryUtil.addToGenerators(generator.getName());
+        summaryService.addToGenerators(generator.getName());
         ret = generator.customize(ret, prePackagePhase);
       }
     }

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/GeneratorManager.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/GeneratorManager.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.ClassUtil;
 import org.eclipse.jkube.kit.common.util.PluginServiceFactory;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 
 /**
@@ -53,6 +54,7 @@ public class GeneratorManager {
       log.verbose(" - %s", generator.getName());
       if (generator.isApplicable(ret)) {
         log.info("Running generator %s", generator.getName());
+        SummaryUtil.addToGenerators(generator.getName());
         ret = generator.customize(ret, prePackagePhase);
       }
     }

--- a/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/GeneratorManagerTest.java
+++ b/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/GeneratorManagerTest.java
@@ -13,11 +13,13 @@
  */
 package org.eclipse.jkube.generator.api;
 
+import java.io.File;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +33,7 @@ import static org.mockito.Mockito.verify;
 class GeneratorManagerTest {
 
   private KitLogger logger;
+  private SummaryService summaryService;
 
   private GeneratorContext generatorContext;
 
@@ -39,6 +42,7 @@ class GeneratorManagerTest {
     logger = spy(new KitLogger.SilentLogger());
     final ProcessorConfig processorConfig = new ProcessorConfig();
     processorConfig.setIncludes(Collections.singletonList("fake-generator"));
+    summaryService = new SummaryService(new File("target"), logger, false);
     generatorContext = GeneratorContext.builder()
         .config(processorConfig)
         .logger(logger)
@@ -51,7 +55,7 @@ class GeneratorManagerTest {
     final List<ImageConfiguration> images = Collections.singletonList(new ImageConfiguration());
     // When
     final List<ImageConfiguration> result = GeneratorManager
-        .generate(images, generatorContext, false);
+        .generate(images, generatorContext, false, summaryService);
     // Then
     assertThat(result)
         .isNotSameAs(images)

--- a/jkube-kit/jkube-kit-micronaut/src/main/java/org/eclipse/jkube/micronaut/enricher/MicronautHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-micronaut/src/main/java/org/eclipse/jkube/micronaut/enricher/MicronautHealthCheckEnricher.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.micronaut.enricher;
 import java.util.Collections;
 
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -85,6 +86,7 @@ public class MicronautHealthCheckEnricher extends AbstractHealthCheckEnricher {
       return null;
     }
 
+    SummaryUtil.addToEnrichers(getName());
     final String firstImagePort = getImages().stream().findFirst()
         .map(ImageConfiguration::getBuild).map(BuildConfiguration::getPorts)
         .orElse(Collections.emptyList()).stream()

--- a/jkube-kit/jkube-kit-micronaut/src/main/java/org/eclipse/jkube/micronaut/enricher/MicronautHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-micronaut/src/main/java/org/eclipse/jkube/micronaut/enricher/MicronautHealthCheckEnricher.java
@@ -16,7 +16,6 @@ package org.eclipse.jkube.micronaut.enricher;
 import java.util.Collections;
 
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -86,7 +85,7 @@ public class MicronautHealthCheckEnricher extends AbstractHealthCheckEnricher {
       return null;
     }
 
-    SummaryUtil.addToEnrichers(getName());
+    getContext().getSummaryService().addToEnrichers(getName());
     final String firstImagePort = getImages().stream().findFirst()
         .map(ImageConfiguration::getBuild).map(BuildConfiguration::getPorts)
         .orElse(Collections.emptyList()).stream()

--- a/jkube-kit/jkube-kit-micronaut/src/test/java/org/eclipse/jkube/micronaut/enricher/MicronautHealthCheckEnricherTest.java
+++ b/jkube-kit/jkube-kit-micronaut/src/test/java/org/eclipse/jkube/micronaut/enricher/MicronautHealthCheckEnricherTest.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.Plugin;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -51,6 +52,7 @@ class MicronautHealthCheckEnricherTest {
         .outputDirectory(new File("target"))
         .build();
     klb = new KubernetesListBuilder();
+    SummaryService summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
     klb.addToItems(new ServiceBuilder()
         .withNewMetadata().withName("make-it-real").endMetadata()
         .build());
@@ -58,6 +60,7 @@ class MicronautHealthCheckEnricherTest {
         .log(new KitLogger.SilentLogger())
         .processorConfig(new ProcessorConfig())
         .project(project)
+        .summaryService(summaryService)
         .build();
   }
 

--- a/jkube-kit/jkube-kit-openliberty/src/main/java/org/eclipse/jkube/openliberty/enricher/OpenLibertyHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-openliberty/src/main/java/org/eclipse/jkube/openliberty/enricher/OpenLibertyHealthCheckEnricher.java
@@ -13,10 +13,6 @@
  */
 package org.eclipse.jkube.openliberty.enricher;
 
-import io.fabric8.kubernetes.api.model.Probe;
-import io.fabric8.kubernetes.api.model.ProbeBuilder;
-import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.microprofile.enricher.AbstractMicroprofileHealthCheckEnricher;
 
@@ -40,44 +36,5 @@ public class OpenLibertyHealthCheckEnricher extends AbstractMicroprofileHealthCh
   @Override
   protected int getPort() {
     return asInteger(Optional.ofNullable(getPortFromConfiguration()).orElse(DEFAULT_OPENLIBERTY_PORT));
-  }
-
-  protected Probe getReadinessProbe() {
-    return discoverOpenLibertyHealthCheck(getConfig(Config.READINESS_PATH), getConfigAsInt(Config.READINESS_INITIAL_DELAY), getConfigAsInt(Config.READINESS_FAILURE_THRESHOLD), getConfigAsInt(Config.READINESS_SUCCESS_THRESHOLD), getConfigAsInt(Config.READINESS_PERIOD_SECONDS));
-  }
-
-  @Override
-  protected Probe getLivenessProbe() {
-    return discoverOpenLibertyHealthCheck(getConfig(Config.LIVENESS_PATH), getConfigAsInt(Config.LIVENESS_INITIAL_DELAY), getConfigAsInt(Config.LIVENESS_FAILURE_THRESHOLD), getConfigAsInt(Config.LIVENESS_SUCCESS_THRESHOLD), getConfigAsInt(Config.LIVENESS_PERIOD_SECONDS));
-  }
-
-  @Override
-  protected Probe getStartupProbe() {
-    if (isStartupEndpointSupported(getContext().getProject())) {
-      return discoverOpenLibertyHealthCheck(getConfig(Config.STARTUP_PATH), getConfigAsInt(Config.STARTUP_INITIAL_DELAY), getConfigAsInt(Config.STARTUP_FAILURE_THRESHOLD), getConfigAsInt(Config.STARTUP_SUCCESS_THRESHOLD), getConfigAsInt(Config.STARTUP_PERIOD_SECONDS));
-    }
-    return null;
-  }
-
-  private Probe discoverOpenLibertyHealthCheck(String path, int initialDelay, int failureThreshold, int successThreshold, int periodSeconds) {
-    if (hasMicroProfileDependency(getContext().getProject()) && isMicroProfileHealthEnabled(getContext().getProject())) {
-      SummaryUtil.addToEnrichers(getName());
-      return new ProbeBuilder()
-          .withNewHttpGet()
-          .withNewPort(asInteger(getConfig(Config.PORT)))
-          .withPath(path)
-          .withScheme(getConfig(Config.SCHEME))
-          .endHttpGet()
-          .withFailureThreshold(failureThreshold)
-          .withSuccessThreshold(successThreshold)
-          .withInitialDelaySeconds(initialDelay)
-          .withPeriodSeconds(periodSeconds)
-          .build();
-    }
-    return null;
-  }
-
-  private int getConfigAsInt(Configs.Config key) {
-    return Integer.parseInt(getConfig(key));
   }
 }

--- a/jkube-kit/jkube-kit-openliberty/src/main/java/org/eclipse/jkube/openliberty/enricher/OpenLibertyHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-openliberty/src/main/java/org/eclipse/jkube/openliberty/enricher/OpenLibertyHealthCheckEnricher.java
@@ -13,6 +13,10 @@
  */
 package org.eclipse.jkube.openliberty.enricher;
 
+import io.fabric8.kubernetes.api.model.Probe;
+import io.fabric8.kubernetes.api.model.ProbeBuilder;
+import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.microprofile.enricher.AbstractMicroprofileHealthCheckEnricher;
 
@@ -36,5 +40,44 @@ public class OpenLibertyHealthCheckEnricher extends AbstractMicroprofileHealthCh
   @Override
   protected int getPort() {
     return asInteger(Optional.ofNullable(getPortFromConfiguration()).orElse(DEFAULT_OPENLIBERTY_PORT));
+  }
+
+  protected Probe getReadinessProbe() {
+    return discoverOpenLibertyHealthCheck(getConfig(Config.READINESS_PATH), getConfigAsInt(Config.READINESS_INITIAL_DELAY), getConfigAsInt(Config.READINESS_FAILURE_THRESHOLD), getConfigAsInt(Config.READINESS_SUCCESS_THRESHOLD), getConfigAsInt(Config.READINESS_PERIOD_SECONDS));
+  }
+
+  @Override
+  protected Probe getLivenessProbe() {
+    return discoverOpenLibertyHealthCheck(getConfig(Config.LIVENESS_PATH), getConfigAsInt(Config.LIVENESS_INITIAL_DELAY), getConfigAsInt(Config.LIVENESS_FAILURE_THRESHOLD), getConfigAsInt(Config.LIVENESS_SUCCESS_THRESHOLD), getConfigAsInt(Config.LIVENESS_PERIOD_SECONDS));
+  }
+
+  @Override
+  protected Probe getStartupProbe() {
+    if (isStartupEndpointSupported(getContext().getProject())) {
+      return discoverOpenLibertyHealthCheck(getConfig(Config.STARTUP_PATH), getConfigAsInt(Config.STARTUP_INITIAL_DELAY), getConfigAsInt(Config.STARTUP_FAILURE_THRESHOLD), getConfigAsInt(Config.STARTUP_SUCCESS_THRESHOLD), getConfigAsInt(Config.STARTUP_PERIOD_SECONDS));
+    }
+    return null;
+  }
+
+  private Probe discoverOpenLibertyHealthCheck(String path, int initialDelay, int failureThreshold, int successThreshold, int periodSeconds) {
+    if (hasMicroProfileDependency(getContext().getProject()) && isMicroProfileHealthEnabled(getContext().getProject())) {
+      SummaryUtil.addToEnrichers(getName());
+      return new ProbeBuilder()
+          .withNewHttpGet()
+          .withNewPort(asInteger(getConfig(Config.PORT)))
+          .withPath(path)
+          .withScheme(getConfig(Config.SCHEME))
+          .endHttpGet()
+          .withFailureThreshold(failureThreshold)
+          .withSuccessThreshold(successThreshold)
+          .withInitialDelaySeconds(initialDelay)
+          .withPeriodSeconds(periodSeconds)
+          .build();
+    }
+    return null;
+  }
+
+  private int getConfigAsInt(Configs.Config key) {
+    return Integer.parseInt(getConfig(key));
   }
 }

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricher.java
@@ -17,7 +17,6 @@ import java.util.function.Function;
 
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.JavaProject;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
 import org.eclipse.jkube.quarkus.QuarkusUtils;
@@ -86,7 +85,7 @@ public class QuarkusHealthCheckEnricher extends AbstractHealthCheckEnricher {
         if (!getContext().hasDependency(QUARKUS_GROUP_ID, "quarkus-smallrye-health")) {
             return null;
         }
-        SummaryUtil.addToEnrichers(getName());
+        getContext().getSummaryService().addToEnrichers(getName());
         return new ProbeBuilder()
             .withNewHttpGet()
               .withNewPort(asInteger(getConfig(Config.PORT)))

--- a/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-quarkus/src/main/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricher.java
@@ -17,6 +17,7 @@ import java.util.function.Function;
 
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
 import org.eclipse.jkube.quarkus.QuarkusUtils;
@@ -85,6 +86,7 @@ public class QuarkusHealthCheckEnricher extends AbstractHealthCheckEnricher {
         if (!getContext().hasDependency(QUARKUS_GROUP_ID, "quarkus-smallrye-health")) {
             return null;
         }
+        SummaryUtil.addToEnrichers(getName());
         return new ProbeBuilder()
             .withNewHttpGet()
               .withNewPort(asInteger(getConfig(Config.PORT)))

--- a/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricherTest.java
+++ b/jkube-kit/jkube-kit-quarkus/src/test/java/org/eclipse/jkube/quarkus/enricher/QuarkusHealthCheckEnricherTest.java
@@ -25,6 +25,7 @@ import org.assertj.core.groups.Tuple;
 import org.eclipse.jkube.kit.common.Dependency;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -52,6 +53,7 @@ class QuarkusHealthCheckEnricherTest {
   void setUp() {
     properties = new Properties();
     klb = new KubernetesListBuilder();
+    SummaryService summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
     // @formatter:off
     klb.addToItems(new DeploymentBuilder()
         .editOrNewSpec()
@@ -76,6 +78,7 @@ class QuarkusHealthCheckEnricherTest {
       .log(new KitLogger.SilentLogger())
       .project(javaProject)
       .processorConfig(new ProcessorConfig())
+      .summaryService(summaryService)
       .build();
   }
 

--- a/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/enricher/SpringBootHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/enricher/SpringBootHealthCheckEnricher.java
@@ -22,7 +22,6 @@ import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.SpringBootConfigurationHelper;
 import org.eclipse.jkube.kit.common.util.SpringBootUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
 import org.apache.commons.lang3.StringUtils;
@@ -87,7 +86,7 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
         try {
             if (getContext().getProjectClassLoaders().isClassInCompileClasspath(true, REQUIRED_CLASSES)) {
                 Properties properties = SpringBootUtil.getSpringBootApplicationProperties(getContext().getProjectClassLoaders().getCompileClassLoader());
-                SummaryUtil.addToEnrichers(getName());
+                getContext().getSummaryService().addToEnrichers(getName());
                 return buildProbe(properties, initialDelay, period, timeout, failureTh, successTh);
             }
         } catch (Exception ex) {

--- a/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/enricher/SpringBootHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/enricher/SpringBootHealthCheckEnricher.java
@@ -22,6 +22,7 @@ import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.util.SpringBootConfigurationHelper;
 import org.eclipse.jkube.kit.common.util.SpringBootUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
 import org.apache.commons.lang3.StringUtils;
@@ -86,6 +87,7 @@ public class SpringBootHealthCheckEnricher extends AbstractHealthCheckEnricher {
         try {
             if (getContext().getProjectClassLoaders().isClassInCompileClasspath(true, REQUIRED_CLASSES)) {
                 Properties properties = SpringBootUtil.getSpringBootApplicationProperties(getContext().getProjectClassLoaders().getCompileClassLoader());
+                SummaryUtil.addToEnrichers(getName());
                 return buildProbe(properties, initialDelay, period, timeout, failureTh, successTh);
             }
         } catch (Exception ex) {

--- a/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/watcher/SpringBootWatcher.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/watcher/SpringBootWatcher.java
@@ -31,6 +31,7 @@ import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.PrefixedLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.ClassUtil;
 import org.eclipse.jkube.kit.common.util.IoUtil;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
@@ -68,7 +69,7 @@ public class SpringBootWatcher extends BaseWatcher {
     }
 
     @Override
-    public void watch(List<ImageConfiguration> configs, String namespace, Collection<HasMetadata> resources, PlatformMode mode) throws Exception {
+    public void watch(List<ImageConfiguration> configs, String namespace, Collection<HasMetadata> resources, PlatformMode mode, SummaryService summaryService) {
         final NamespacedKubernetesClient kubernetes;
         if (namespace != null) {
             kubernetes = getContext().getJKubeServiceHub().getClient().adapt(NamespacedKubernetesClient.class).inNamespace(namespace);

--- a/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/enricher/AbstractSpringBootHealthCheckEnricherTestSupport.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/enricher/AbstractSpringBootHealthCheckEnricherTestSupport.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.api.model.Probe;
 import org.eclipse.jkube.kit.common.Dependency;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.SpringBootConfigurationHelper;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
@@ -60,6 +61,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherTestSupport {
     @BeforeEach
     void init(@TempDir Path project) throws IOException {
         projectClassLoaders = mock(ProjectClassLoaders.class, RETURNS_DEEP_STUBS);
+        SummaryService summaryService = mock(SummaryService.class);
         context = spy(JKubeEnricherContext.builder()
           .log(new KitLogger.SilentLogger())
           .project(JavaProject.builder()
@@ -73,6 +75,7 @@ public abstract class AbstractSpringBootHealthCheckEnricherTestSupport {
                 .version(getSpringBootVersion())
               .build()))
             .build())
+          .summaryService(summaryService)
           .processorConfig(new ProcessorConfig())
           .build());
         when(context.getProjectClassLoaders()).thenReturn(projectClassLoaders);

--- a/jkube-kit/jkube-kit-thorntail-v2/src/main/java/org/eclipse/jkube/thorntail/v2/enricher/ThorntailV2HealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-thorntail-v2/src/main/java/org/eclipse/jkube/thorntail/v2/enricher/ThorntailV2HealthCheckEnricher.java
@@ -18,6 +18,7 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.common.util.ThorntailUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
@@ -68,6 +69,7 @@ public class ThorntailV2HealthCheckEnricher extends AbstractHealthCheckEnricher 
 
         if (getContext().hasDependency(IO_THORNTAIL, "monitor")
                 || getContext().hasDependency(IO_THORNTAIL, "microprofile-health")) {
+            SummaryUtil.addToEnrichers(getName());
             Integer port = getPort();
             // scheme must be in upper case in k8s
             String scheme = getScheme().toUpperCase();

--- a/jkube-kit/jkube-kit-thorntail-v2/src/main/java/org/eclipse/jkube/thorntail/v2/enricher/ThorntailV2HealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-thorntail-v2/src/main/java/org/eclipse/jkube/thorntail/v2/enricher/ThorntailV2HealthCheckEnricher.java
@@ -18,7 +18,6 @@ import io.fabric8.kubernetes.api.model.ProbeBuilder;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.common.util.ThorntailUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
@@ -69,7 +68,7 @@ public class ThorntailV2HealthCheckEnricher extends AbstractHealthCheckEnricher 
 
         if (getContext().hasDependency(IO_THORNTAIL, "monitor")
                 || getContext().hasDependency(IO_THORNTAIL, "microprofile-health")) {
-            SummaryUtil.addToEnrichers(getName());
+            getContext().getSummaryService().addToEnrichers(getName());
             Integer port = getPort();
             // scheme must be in upper case in k8s
             String scheme = getScheme().toUpperCase();

--- a/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricher.java
@@ -20,6 +20,7 @@ import io.fabric8.kubernetes.api.model.ProbeFluent;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
 
@@ -127,6 +128,7 @@ public class VertxHealthCheckEnricher extends AbstractHealthCheckEnricher {
         if (!isApplicable()) {
             return null;
         }
+        SummaryUtil.addToEnrichers(getName());
         // We don't allow to set the HOST, because it should rather be configured in the HTTP header (Host header)
         // cf. https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
         String type = getStringValue(Config.TYPE, readiness).orElse("http").toUpperCase();

--- a/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricher.java
@@ -20,7 +20,6 @@ import io.fabric8.kubernetes.api.model.ProbeFluent;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.eclipse.jkube.kit.common.Configs;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
 
@@ -128,7 +127,7 @@ public class VertxHealthCheckEnricher extends AbstractHealthCheckEnricher {
         if (!isApplicable()) {
             return null;
         }
-        SummaryUtil.addToEnrichers(getName());
+        getContext().getSummaryService().addToEnrichers(getName());
         // We don't allow to set the HOST, because it should rather be configured in the HTTP header (Host header)
         // cf. https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
         String type = getStringValue(Config.TYPE, readiness).orElse("http").toUpperCase();

--- a/jkube-kit/jkube-kit-vertx/src/test/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricherTest.java
+++ b/jkube-kit/jkube-kit-vertx/src/test/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricherTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.vertx.enricher;
 
+import java.io.File;
 import java.util.AbstractMap;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import io.fabric8.kubernetes.client.utils.Serialization;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.Plugin;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 
@@ -61,12 +63,14 @@ class VertxHealthCheckEnricherTest {
         plexusMavenConfig = new TreeMap<>();
         jKubePluginConfiguration = new HashMap<>();
         properties = new Properties();
+        SummaryService summaryService = new SummaryService(new File("target"), new KitLogger.SilentLogger(), false);
         final ProcessorConfig processorConfig = new ProcessorConfig();
         processorConfig.setConfig(Collections.singletonMap("jkube-healthcheck-vertx", plexusMavenConfig));
         context = JKubeEnricherContext.builder()
             .log(new KitLogger.SilentLogger())
             .processorConfig(processorConfig)
             .project(createNewJavaProjectWithVertxPlugin("io.reactiverse", "vertx-maven-plugin"))
+            .summaryService(summaryService)
             .build();
     }
 

--- a/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/enricher/WildflyJARHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/enricher/WildflyJARHealthCheckEnricher.java
@@ -25,7 +25,6 @@ import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.Plugin;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
@@ -95,7 +94,7 @@ public class WildflyJARHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
     private Probe discoverWildflyJARHealthCheck(Config path, Config initialDelay) {
         if (isAvailable()) {
-            SummaryUtil.addToEnrichers(getName());
+            getContext().getSummaryService().addToEnrichers(getName());
             int port = asInt(getConfig(Config.PORT));
             if (port <= 0) {
                 return null;

--- a/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/enricher/WildflyJARHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/enricher/WildflyJARHealthCheckEnricher.java
@@ -25,6 +25,7 @@ import org.eclipse.jkube.kit.common.Configs;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.Plugin;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.eclipse.jkube.kit.enricher.specific.AbstractHealthCheckEnricher;
@@ -94,6 +95,7 @@ public class WildflyJARHealthCheckEnricher extends AbstractHealthCheckEnricher {
 
     private Probe discoverWildflyJARHealthCheck(Config path, Config initialDelay) {
         if (isAvailable()) {
+            SummaryUtil.addToEnrichers(getName());
             int port = asInt(getConfig(Config.PORT));
             if (port <= 0) {
                 return null;

--- a/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmService.java
+++ b/jkube-kit/resource/helm/src/main/java/org/eclipse/jkube/kit/resource/helm/HelmService.java
@@ -32,13 +32,12 @@ import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.RegistryConfig;
 import org.eclipse.jkube.kit.common.RegistryServerConfiguration;
 import org.eclipse.jkube.kit.common.ResourceFileType;
-import org.eclipse.jkube.kit.common.summary.Summary;
 import org.eclipse.jkube.kit.common.archive.ArchiveCompression;
 import org.eclipse.jkube.kit.common.archive.JKubeTarArchiver;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.FileUtil;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 
 import com.google.common.collect.Streams;
@@ -66,10 +65,12 @@ public class HelmService {
 
   private final JKubeConfiguration jKubeConfiguration;
   private final KitLogger logger;
+  private final SummaryService summaryService;
 
-  public HelmService(JKubeConfiguration jKubeConfiguration, KitLogger logger) {
+  public HelmService(JKubeConfiguration jKubeConfiguration, KitLogger logger, SummaryService summaryService) {
     this.jKubeConfiguration = jKubeConfiguration;
     this.logger = logger;
+    this.summaryService = summaryService;
   }
 
   /**
@@ -108,12 +109,12 @@ public class HelmService {
       logger.debug("Creating Helm configuration Tarball: '%s'", tarballFile.getAbsolutePath());
       final Consumer<TarArchiveEntry> prependNameAsDirectory = tae ->
           tae.setName(String.format("%s/%s", helmConfig.getChart(), tae.getName()));
-      SummaryUtil.setHelmChartName(helmConfig.getChart());
-      SummaryUtil.setHelmChartLocation(outputDir);
+      summaryService.setHelmChartName(helmConfig.getChart());
+      summaryService.setHelmChartLocation(outputDir);
       File helmTarball = JKubeTarArchiver.createTarBall(
           tarballFile, outputDir, FileUtil.listFilesAndDirsRecursivelyInDirectory(outputDir), Collections.emptyMap(),
           ArchiveCompression.fromFileName(tarballFile.getName()), null, prependNameAsDirectory);
-      SummaryUtil.setHelmChartCompressedLocation(helmTarball);
+      summaryService.setHelmChartCompressedLocation(helmTarball);
       Optional.ofNullable(helmConfig.getGeneratedChartListeners()).orElse(Collections.emptyList())
           .forEach(listener -> listener.chartFileGenerated(helmConfig, helmType, tarballFile));
     }
@@ -141,7 +142,7 @@ public class HelmService {
           .orElse(s -> s);
       setAuthentication(helmRepository, logger, registryServerConfigurations, passwordDecryptor);
       uploadHelmChart(helm, helmRepository);
-      SummaryUtil.setHelmRepository(helmRepository.getName());
+      summaryService.setHelmRepository(helmRepository.getName());
     } else {
       String error = "No repository or invalid repository configured for upload";
       logger.error(error);

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceIT.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceIT.java
@@ -27,6 +27,7 @@ import java.util.stream.Collectors;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.assertj.ArchiveAssertions;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -51,7 +52,7 @@ class HelmServiceIT {
   @BeforeEach
   void setUp(@TempDir Path temporaryFolder) throws Exception {
     mapper = new ObjectMapper(new YAMLFactory());
-    helmService = new HelmService(new JKubeConfiguration(), new KitLogger.SilentLogger());
+    helmService = new HelmService(new JKubeConfiguration(), new KitLogger.SilentLogger(), new SummaryService(temporaryFolder.toFile(), new KitLogger.SilentLogger(), false));
     helmOutputDir = Files.createDirectory(temporaryFolder.resolve("helm-output")).toFile();
     helmConfig = new HelmConfig();
     helmConfig.setSourceDir(new File(HelmServiceIT.class.getResource("/it/sources").toURI()).getAbsolutePath());

--- a/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceTest.java
+++ b/jkube-kit/resource/helm/src/test/java/org/eclipse/jkube/kit/resource/helm/HelmServiceTest.java
@@ -25,6 +25,7 @@ import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.RegistryConfig;
 import org.eclipse.jkube.kit.common.RegistryServerConfiguration;
 import org.eclipse.jkube.kit.common.ResourceFileType;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
 import org.eclipse.jkube.kit.resource.helm.HelmConfig.HelmType;
 import org.junit.jupiter.api.AfterEach;
@@ -57,7 +58,8 @@ class HelmServiceTest {
     helmConfig = HelmConfig.builder();
     jKubeConfiguration = JKubeConfiguration.builder()
         .registryConfig(RegistryConfig.builder().settings(new ArrayList<>()).build()).build();
-    helmService = new HelmService(jKubeConfiguration, new KitLogger.SilentLogger());
+    SummaryService summaryService = mock(SummaryService.class);
+    helmService = new HelmService(jKubeConfiguration, new KitLogger.SilentLogger(), summaryService);
   }
 
   @AfterEach

--- a/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/DefaultResourceService.java
+++ b/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/DefaultResourceService.java
@@ -24,6 +24,7 @@ import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.ResourceFileType;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
 import org.eclipse.jkube.kit.common.util.ResourceClassifier;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.common.util.ValidationUtil;
 import org.eclipse.jkube.kit.config.resource.EnricherManager;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -74,6 +75,7 @@ public class DefaultResourceService implements ResourceService {
       interpolateTemplateVariables(resources, file);
     }
 
+    SummaryUtil.setAggregateResourceFile(file);
     return file;
   }
 

--- a/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/DefaultResourceService.java
+++ b/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/DefaultResourceService.java
@@ -22,9 +22,9 @@ import javax.validation.ConstraintViolationException;
 
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.ResourceFileType;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
 import org.eclipse.jkube.kit.common.util.ResourceClassifier;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.common.util.ValidationUtil;
 import org.eclipse.jkube.kit.config.resource.EnricherManager;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -63,19 +63,19 @@ public class DefaultResourceService implements ResourceService {
   }
 
   @Override
-  public File writeResources(KubernetesList resources, ResourceClassifier classifier, KitLogger log) throws IOException {
+  public File writeResources(KubernetesList resources, ResourceClassifier classifier, KitLogger log, SummaryService summaryService) throws IOException {
     final File targetDir = resourceServiceConfig.getTargetDir();
     final ResourceFileType resourceFileType = resourceServiceConfig.getResourceFileType();
     // write kubernetes.yml / openshift.yml
     File resourceFileBase = new File(targetDir, classifier.getValue());
 
-    File file = writeResourcesIndividualAndComposite(resources, resourceFileBase, resourceFileType, log);
+    File file = writeResourcesIndividualAndComposite(resources, resourceFileBase, resourceFileType, log, summaryService);
     // Resolve template placeholders
     if (resourceServiceConfig.isInterpolateTemplateParameters()) {
       interpolateTemplateVariables(resources, file);
     }
 
-    SummaryUtil.setAggregateResourceFile(file);
+    summaryService.setAggregateResourceFile(file);
     return file;
   }
 

--- a/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/WriteUtil.java
+++ b/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/WriteUtil.java
@@ -21,9 +21,9 @@ import io.fabric8.openshift.api.model.Template;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.ResourceFileType;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 
 import java.io.File;
@@ -41,7 +41,7 @@ class WriteUtil {
   private WriteUtil(){ }
 
   static File writeResourcesIndividualAndComposite(
-      KubernetesList resources, File resourceFileBase, ResourceFileType resourceFileType, KitLogger log) throws IOException {
+      KubernetesList resources, File resourceFileBase, ResourceFileType resourceFileType, KitLogger log, SummaryService summaryService) throws IOException {
 
     resources.getItems().sort(COMPARATOR);
     // entity is object which will be sent to writeResource for openshift.yml
@@ -62,12 +62,12 @@ class WriteUtil {
 
     // write separate files, one for each resource item
     // resources passed to writeIndividualResources is also new one.
-    writeIndividualResources(resources, resourceFileBase, resourceFileType, log);
+    writeIndividualResources(resources, resourceFileBase, resourceFileType, log, summaryService);
     return file;
   }
 
   private static void writeIndividualResources(
-      KubernetesList resources, File targetDir, ResourceFileType resourceFileType, KitLogger log) throws IOException {
+      KubernetesList resources, File targetDir, ResourceFileType resourceFileType, KitLogger log, SummaryService summaryService) throws IOException {
     final Map<String, Integer> generatedFiles = new HashMap<>();
     for (HasMetadata item : resources.getItems()) {
       String name = KubernetesHelper.getName(item);
@@ -83,7 +83,7 @@ class WriteUtil {
 
       // Here we are writing individual file for all the resources.
       File itemTarget = new File(targetDir, fileName);
-      SummaryUtil.addGeneratedResourceFile(Optional.ofNullable(resourceFileType)
+      summaryService.addGeneratedResourceFile(Optional.ofNullable(resourceFileType)
           .map(r -> r.addExtensionIfMissing(itemTarget))
           .orElse(itemTarget));
       writeResource(itemTarget, item, resourceFileType);

--- a/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/WriteUtil.java
+++ b/jkube-kit/resource/service/src/main/java/org/eclipse/jkube/kit/resource/service/WriteUtil.java
@@ -23,12 +23,14 @@ import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.ResourceFileType;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.eclipse.jkube.kit.resource.service.TemplateUtil.getSingletonTemplate;
 
@@ -81,6 +83,9 @@ class WriteUtil {
 
       // Here we are writing individual file for all the resources.
       File itemTarget = new File(targetDir, fileName);
+      SummaryUtil.addGeneratedResourceFile(Optional.ofNullable(resourceFileType)
+          .map(r -> r.addExtensionIfMissing(itemTarget))
+          .orElse(itemTarget));
       writeResource(itemTarget, item, resourceFileType);
     }
   }

--- a/jkube-kit/resource/service/src/test/java/org/eclipse/jkube/kit/resource/service/DefaultResourceServiceTest.java
+++ b/jkube-kit/resource/service/src/test/java/org/eclipse/jkube/kit/resource/service/DefaultResourceServiceTest.java
@@ -26,6 +26,7 @@ import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.ResourceFileType;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.ResourceClassifier;
 import org.eclipse.jkube.kit.config.resource.EnricherManager;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
@@ -53,11 +54,13 @@ class DefaultResourceServiceTest {
   private File targetDir;
   private ResourceServiceConfig resourceServiceConfig;
   private DefaultResourceService defaultResourceService;
+  private SummaryService summaryService;
 
   @BeforeEach
   void init(@TempDir Path temporaryFolder) throws IOException {
     enricherManager = mock(EnricherManager.class);
     kitLogger = new KitLogger.SilentLogger();
+    summaryService = mock(SummaryService.class);
     targetDir = Files.createDirectory(temporaryFolder.resolve("target")).toFile();
     resourceServiceConfig = ResourceServiceConfig.builder()
         .interpolateTemplateParameters(true)
@@ -114,9 +117,9 @@ class DefaultResourceServiceTest {
       MockedStatic<TemplateUtil> templateUtil = mockStatic(TemplateUtil.class)
     ) {
       // When
-      defaultResourceService.writeResources(null, ResourceClassifier.KUBERNETES, kitLogger);
+      defaultResourceService.writeResources(null, ResourceClassifier.KUBERNETES, kitLogger, summaryService);
       // Then
-      writeUtil.verify(() -> WriteUtil.writeResourcesIndividualAndComposite(isNull(), eq(new File(targetDir, "kubernetes")), eq(ResourceFileType.yaml), eq(kitLogger)), times(1));
+      writeUtil.verify(() -> WriteUtil.writeResourcesIndividualAndComposite(isNull(), eq(new File(targetDir, "kubernetes")), eq(ResourceFileType.yaml), eq(kitLogger), eq(summaryService)), times(1));
       templateUtil.verify(() -> TemplateUtil.interpolateTemplateVariables(isNull(), any()), times(1));
     }
   }

--- a/jkube-kit/resource/service/src/test/java/org/eclipse/jkube/kit/resource/service/WriteUtilTest.java
+++ b/jkube-kit/resource/service/src/test/java/org/eclipse/jkube/kit/resource/service/WriteUtilTest.java
@@ -20,6 +20,7 @@ import java.nio.file.Files;
 import io.fabric8.kubernetes.api.model.GenericKubernetesResource;
 import io.fabric8.kubernetes.api.model.ObjectMetaBuilder;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
 
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
@@ -36,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 
@@ -48,18 +50,22 @@ class WriteUtilTest {
 
   private KubernetesListBuilder klb;
   private File resourceFileBase;
+  private SummaryService summaryService;
 
   @BeforeEach
   void initGlobalVariables()  {
     log = new KitLogger.SilentLogger();
+    summaryService = mock(SummaryService.class);
     resourceUtil = mockStatic(ResourceUtil.class);
     klb = new KubernetesListBuilder();
     resourceFileBase = temporaryFolder;
   }
+
   @AfterEach
   public void close() {
     resourceUtil.close();
   }
+
   @Test
   void writeResource() throws IOException {
     // Given
@@ -88,7 +94,7 @@ class WriteUtilTest {
   @Test
   void writeResourcesIndividualAndCompositeWithNoResourcesShouldOnlyWriteComposite() throws IOException {
     // When
-    WriteUtil.writeResourcesIndividualAndComposite(klb.build(), resourceFileBase, null, log);
+    WriteUtil.writeResourcesIndividualAndComposite(klb.build(), resourceFileBase, null, log, summaryService);
     // Then
     verifyResourceUtilSave(resourceFileBase);
   }
@@ -102,7 +108,7 @@ class WriteUtilTest {
       new SecretBuilder().withNewMetadata().withName(" ").endMetadata().build()
     );
     // When
-    WriteUtil.writeResourcesIndividualAndComposite(klb.build(), resourceFileBase, null, log);
+    WriteUtil.writeResourcesIndividualAndComposite(klb.build(), resourceFileBase, null, log, summaryService);
     // Then
     verifyResourceUtilSave(resourceFileBase);
     verifyResourceUtilSave(new File(resourceFileBase, "cm-1-configmap"));
@@ -120,7 +126,7 @@ class WriteUtilTest {
         genericCustomResource("CustomResourceOfKind3")
     );
     // When
-    WriteUtil.writeResourcesIndividualAndComposite(klb.build(), resourceFileBase, null, log);
+    WriteUtil.writeResourcesIndividualAndComposite(klb.build(), resourceFileBase, null, log, summaryService);
     // Then
     verifyResourceUtilSave(resourceFileBase);
     verifyResourceUtilSave(new File(resourceFileBase, "cm-1-configmap"));

--- a/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/Watcher.java
+++ b/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/Watcher.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.jkube.kit.common.Named;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 
@@ -41,8 +42,9 @@ public interface Watcher extends Named {
      * @param namespace namespace in which resources are deployed
      * @param resources list of resources applied
      * @param mode {@link PlatformMode}
+     * @param summaryService {@link SummaryService}
      * @throws Exception in case of any failure
      */
-    void watch(List<ImageConfiguration> configs, String namespace, Collection<HasMetadata> resources, PlatformMode mode) throws Exception;
+    void watch(List<ImageConfiguration> configs, String namespace, Collection<HasMetadata> resources, PlatformMode mode, SummaryService summaryService);
 
 }

--- a/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/WatcherManager.java
+++ b/jkube-kit/watcher/api/src/main/java/org/eclipse/jkube/watcher/api/WatcherManager.java
@@ -73,6 +73,6 @@ public class WatcherManager {
     }
 
     log.info("Running watcher %s", chosen.getName());
-    chosen.watch(ret, namespace, resources, mode);
+    chosen.watch(ret, namespace, resources, mode, watcherCtx.getJKubeServiceHub().getSummaryService());
   }
 }

--- a/jkube-kit/watcher/api/src/test/java/org/eclipse/jkube/watcher/api/WatcherManagerTest.java
+++ b/jkube-kit/watcher/api/src/test/java/org/eclipse/jkube/watcher/api/WatcherManagerTest.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.resource.PlatformMode;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
@@ -85,7 +86,7 @@ class WatcherManagerTest {
     }
 
     @Override
-    public void watch(List<ImageConfiguration> configs, String namespace, Collection<HasMetadata> resources, PlatformMode mode) {
+    public void watch(List<ImageConfiguration> configs, String namespace, Collection<HasMetadata> resources, PlatformMode mode, SummaryService summaryService) {
       configs.forEach(ic -> ic.setName("processed-by-test"));
     }
   }

--- a/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
+++ b/jkube-kit/watcher/standard/src/main/java/org/eclipse/jkube/watcher/standard/DockerImageWatcher.java
@@ -25,6 +25,7 @@ import org.eclipse.jkube.kit.build.service.docker.WatchService;
 import org.eclipse.jkube.kit.build.service.docker.helper.ImageNameFormatter;
 import org.eclipse.jkube.kit.build.service.docker.watch.WatchContext;
 import org.eclipse.jkube.kit.build.service.docker.watch.WatchException;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
@@ -92,7 +93,7 @@ public class DockerImageWatcher extends BaseWatcher {
     }
 
     @Override
-    public void watch(List<ImageConfiguration> configs, String namespace, final Collection<HasMetadata> resources, PlatformMode mode) {
+    public void watch(List<ImageConfiguration> configs, String namespace, final Collection<HasMetadata> resources, PlatformMode mode, SummaryService summaryService) {
 
         WatchContext watchContext = getContext().getWatchContext();
 
@@ -105,7 +106,7 @@ public class DockerImageWatcher extends BaseWatcher {
 
         DockerServiceHub hub = getContext().getJKubeServiceHub().getDockerServiceHub();
         try {
-            hub.getWatchService().watch(watchContext, getContext().getBuildContext(), configs);
+            hub.getWatchService().watch(watchContext, getContext().getBuildContext(), configs, getContext().getJKubeServiceHub().getSummaryService());
         } catch (Exception ex) {
             throw new RuntimeException("Error while watching", ex);
         }

--- a/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherTest.java
+++ b/jkube-kit/watcher/standard/src/test/java/org/eclipse/jkube/watcher/standard/DockerImageWatcherTest.java
@@ -20,6 +20,7 @@ import org.eclipse.jkube.kit.build.service.docker.watch.CopyFilesTask;
 import org.eclipse.jkube.kit.build.service.docker.watch.ExecTask;
 import org.eclipse.jkube.kit.build.service.docker.watch.WatchContext;
 import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.watcher.api.WatcherContext;
@@ -42,6 +43,7 @@ import static org.mockito.Mockito.when;
 class DockerImageWatcherTest {
   private WatchService watchService;
   private DockerImageWatcher dockerImageWatcher;
+  private SummaryService summaryService;
 
   @BeforeEach
   public void setUp() {
@@ -49,6 +51,7 @@ class DockerImageWatcherTest {
     ClusterAccess mockedClusterAccess = mock(ClusterAccess.class);
     watchService = mock(WatchService.class);
     DockerServiceHub mockedDockerServiceHub = mock(DockerServiceHub.class,RETURNS_DEEP_STUBS);
+    summaryService = mock(SummaryService.class);
     dockerImageWatcher = new DockerImageWatcher(watcherContext);
     when(mockedDockerServiceHub.getWatchService()).thenReturn(watchService);
     when(watcherContext.getJKubeServiceHub().getDockerServiceHub()).thenReturn(mockedDockerServiceHub);
@@ -79,9 +82,9 @@ class DockerImageWatcherTest {
     // Given
     ArgumentCaptor<WatchContext> watchContextArgumentCaptor = ArgumentCaptor.forClass(WatchContext.class);
     // When
-    dockerImageWatcher.watch(null, null, null, null);
+    dockerImageWatcher.watch(null, null, null, null, summaryService);
     // Then
-    verify(watchService).watch(watchContextArgumentCaptor.capture(),any(),any());
+    verify(watchService).watch(watchContextArgumentCaptor.capture(),any(),any(), any());
     assertThat(watchContextArgumentCaptor.getValue())
         .isNotNull()
         .extracting("imageCustomizer","containerRestarter","containerCommandExecutor","containerCopyTask")
@@ -93,8 +96,8 @@ class DockerImageWatcherTest {
     try (MockedConstruction<PodExecutor> podExecutorMockedConstruction = mockConstruction(PodExecutor.class)) {
       // Given
       ArgumentCaptor<WatchContext>watchContextArgumentCaptor=ArgumentCaptor.forClass(WatchContext.class);
-      dockerImageWatcher.watch(null,null,null,null);
-      verify(watchService).watch(watchContextArgumentCaptor.capture(),any(),any());
+      dockerImageWatcher.watch(null,null,null,null, summaryService);
+      verify(watchService).watch(watchContextArgumentCaptor.capture(),any(),any(), any());
       final ExecTask execTask=watchContextArgumentCaptor.getValue().getContainerCommandExecutor();
       //When
       execTask.exec("thecommand");
@@ -109,8 +112,8 @@ class DockerImageWatcherTest {
     try (MockedConstruction<PodExecutor> podExecutorMockedConstruction = mockConstruction(PodExecutor.class)) {
       // Given
       ArgumentCaptor<WatchContext> watchContextArgumentCaptor = ArgumentCaptor.forClass(WatchContext.class);
-      dockerImageWatcher.watch(null,null,null,null);
-      verify(watchService).watch(watchContextArgumentCaptor.capture(),any(),any());
+      dockerImageWatcher.watch(null,null,null,null, summaryService);
+      verify(watchService).watch(watchContextArgumentCaptor.capture(),any(),any(), any());
       final CopyFilesTask copyFilesTask = watchContextArgumentCaptor.getValue().getContainerCopyTask();
       // When
       copyFilesTask.copy(null);

--- a/kubernetes-maven-plugin/doc/src/main/asciidoc/index.adoc
+++ b/kubernetes-maven-plugin/doc/src/main/asciidoc/index.adoc
@@ -40,6 +40,7 @@ include::inc/_access.adoc[]
 
 include::inc/_registry.adoc[]
 include::inc/_authentication.adoc[]
+include::{kitdoc-path}/inc/_summary.adoc[]
 include::inc/_volumes.adoc[]
 include::inc/_integrations.adoc[]
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
@@ -22,6 +22,7 @@ import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.MavenUtil;
 import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.service.ApplyService;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 import org.eclipse.jkube.maven.plugin.mojo.ManifestProvider;
@@ -187,13 +188,12 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
             applyEntities(kubernetes, manifest.getName(), entities);
             log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up", clusterAccess.isOpenShift() ? "oc" : "kubectl");
         } catch (KubernetesClientException e) {
-            KubernetesResourceUtil.handleKubernetesClientException(e, this.log);
+            KubernetesResourceUtil.handleKubernetesClientException(e, this.log, summaryEnabled);
         } catch(InterruptedException ex) {
             Thread.currentThread().interrupt();
         } catch (Exception e) {
-            throw new MojoExecutionException(e.getMessage(), e);
+            SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, e.getMessage(), () -> new MojoExecutionException(e.getMessage(), e));
         }
-
     }
 
     protected void applyEntities(final KubernetesClient kubernetes, String fileName, final Collection<HasMetadata> entities) throws InterruptedException {

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojo.java
@@ -22,7 +22,6 @@ import org.eclipse.jkube.kit.common.KitLogger;
 import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.MavenUtil;
 import org.eclipse.jkube.kit.common.util.OpenshiftHelper;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.service.ApplyService;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 import org.eclipse.jkube.maven.plugin.mojo.ManifestProvider;
@@ -39,6 +38,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 import org.apache.maven.project.MavenProject;
 
 import static org.eclipse.jkube.kit.config.service.kubernetes.KubernetesClientUtil.resolveFallbackNamespace;
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.printSummary;
 
 /**
  * Base class for goals which deploy the generated artifacts into the Kubernetes cluster
@@ -158,7 +159,7 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
     public void executeInternal() throws MojoExecutionException {
         try (KubernetesClient kubernetes = jkubeServiceHub.getClient()) {
             applyService = jkubeServiceHub.getApplyService();
-            initServices(kubernetes);
+            initServices();
 
             URL masterUrl = kubernetes.getMasterUrl();
             final File manifest = getManifest(kubernetes);
@@ -188,20 +189,21 @@ public class ApplyMojo extends AbstractJKubeMojo implements ManifestProvider {
             applyEntities(kubernetes, manifest.getName(), entities);
             log.info("[[B]]HINT:[[B]] Use the command `%s get pods -w` to watch your pods start up", clusterAccess.isOpenShift() ? "oc" : "kubectl");
         } catch (KubernetesClientException e) {
-            KubernetesResourceUtil.handleKubernetesClientException(e, this.log, summaryEnabled);
-        } catch(InterruptedException ex) {
-            Thread.currentThread().interrupt();
+            IllegalStateException illegalStateException = KubernetesResourceUtil.handleKubernetesClientException(e, this.log, jkubeServiceHub.getSummaryService());
+            printSummary(jkubeServiceHub);
+            throw illegalStateException;
         } catch (Exception e) {
-            SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, e.getMessage(), () -> new MojoExecutionException(e.getMessage(), e));
+            handleExceptionAndSummary(jkubeServiceHub, e);
+            throw new MojoExecutionException(e.getMessage(), e);
         }
     }
 
-    protected void applyEntities(final KubernetesClient kubernetes, String fileName, final Collection<HasMetadata> entities) throws InterruptedException {
+    protected void applyEntities(final KubernetesClient kubernetes, String fileName, final Collection<HasMetadata> entities) {
         KitLogger serviceLogger = createLogger("[[G]][SVC][[G]] [[s]]");
         applyService.applyEntities(fileName, entities, serviceLogger, serviceUrlWaitTimeSeconds);
     }
 
-    protected void initServices(KubernetesClient kubernetes) {
+    protected void initServices() {
         log.debug("No services required in ApplyMojo");
     }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmMojo.java
@@ -17,6 +17,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.resource.helm.HelmConfig;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -65,7 +66,7 @@ public class HelmMojo extends AbstractJKubeMojo {
           .build();
       jkubeServiceHub.getHelmService().generateHelmCharts(helm);
     } catch (IOException exception) {
-      throw new MojoExecutionException(exception.getMessage());
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, exception.getMessage(), () -> new MojoExecutionException(exception.getMessage()));
     }
   }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmMojo.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.resource.helm.HelmConfig;
 
 import org.apache.maven.plugin.MojoExecutionException;
@@ -27,6 +26,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.project.MavenProjectHelper;
 
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
 import static org.eclipse.jkube.kit.resource.helm.HelmServiceUtil.initHelmConfig;
 
 /**
@@ -66,7 +66,8 @@ public class HelmMojo extends AbstractJKubeMojo {
           .build();
       jkubeServiceHub.getHelmService().generateHelmCharts(helm);
     } catch (IOException exception) {
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, exception.getMessage(), () -> new MojoExecutionException(exception.getMessage()));
+      handleExceptionAndSummary(jkubeServiceHub, exception);
+      throw new MojoExecutionException(exception.getMessage());
     }
   }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmPushMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmPushMojo.java
@@ -17,9 +17,9 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
 
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
 import static org.eclipse.jkube.kit.resource.helm.HelmServiceUtil.initHelmPushConfig;
 
 @Mojo(name = "helm-push", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.COMPILE)
@@ -39,7 +39,8 @@ public class HelmPushMojo extends HelmMojo {
       jkubeServiceHub.getHelmService().uploadHelmChart(helm);
     } catch (Exception exp) {
       getKitLogger().error("Error performing helm push", exp);
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, exp.getMessage(), () -> new MojoExecutionException(exp.getMessage(), exp));
+      handleExceptionAndSummary(jkubeServiceHub, exp);
+      throw new MojoExecutionException(exp.getMessage(), exp);
     }
   }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmPushMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmPushMojo.java
@@ -17,6 +17,7 @@ import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.sonatype.plexus.components.sec.dispatcher.DefaultSecDispatcher;
 
 import static org.eclipse.jkube.kit.resource.helm.HelmServiceUtil.initHelmPushConfig;
@@ -38,7 +39,7 @@ public class HelmPushMojo extends HelmMojo {
       jkubeServiceHub.getHelmService().uploadHelmChart(helm);
     } catch (Exception exp) {
       getKitLogger().error("Error performing helm push", exp);
-      throw new MojoExecutionException(exp.getMessage(), exp);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, exp.getMessage(), () -> new MojoExecutionException(exp.getMessage(), exp));
     }
   }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/PushMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/PushMojo.java
@@ -18,7 +18,8 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
+
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
 
 /**
  * Uploads the built Docker images to a Docker registry
@@ -59,7 +60,8 @@ public class PushMojo extends AbstractDockerMojo {
         try {
             jkubeServiceHub.getBuildService().push(getResolvedImages(), retries, getRegistryConfig(pushRegistry), skipTag);
         } catch (Exception ex) {
-            SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, ex.getMessage(), () -> new MojoExecutionException(ex.getMessage(), ex));
+            handleExceptionAndSummary(jkubeServiceHub, ex);
+            throw new MojoExecutionException(ex.getMessage(), ex);
         }
     }
 }

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/PushMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/PushMojo.java
@@ -18,6 +18,7 @@ import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 
 /**
  * Uploads the built Docker images to a Docker registry
@@ -58,7 +59,7 @@ public class PushMojo extends AbstractDockerMojo {
         try {
             jkubeServiceHub.getBuildService().push(getResolvedImages(), retries, getRegistryConfig(pushRegistry), skipTag);
         } catch (Exception ex) {
-            throw new MojoExecutionException(ex.getMessage(), ex);
+            SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, ex.getMessage(), () -> new MojoExecutionException(ex.getMessage(), ex));
         }
     }
 }

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojo.java
@@ -32,6 +32,7 @@ import org.eclipse.jkube.kit.common.util.LazyBuilder;
 import org.eclipse.jkube.kit.common.util.MavenUtil;
 import org.eclipse.jkube.kit.common.util.ResourceClassifier;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.common.util.validator.ResourceValidator;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.JKubeBuildStrategy;
@@ -219,7 +220,7 @@ public class ResourceMojo extends AbstractJKubeMojo {
                 projectHelper.attachArtifact(project, this.resourceFileType.getArtifactType(), resourceClassifier.getValue(), artifact);
             }
         } catch (IOException e) {
-            throw new MojoExecutionException("Failed to generate kubernetes descriptor", e);
+            SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, e.getMessage(), () -> new MojoExecutionException("Failed to generate kubernetes descriptor", e));
         }
     }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojo.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.maven.plugin.mojo.ManifestProvider;
 import org.eclipse.jkube.maven.plugin.mojo.build.AbstractJKubeMojo;
 
@@ -70,7 +71,7 @@ public class UndeployMojo extends AbstractJKubeMojo implements ManifestProvider 
     try {
       undeploy();
     } catch (IOException ex) {
-      throw new MojoExecutionException(ex.getMessage(), ex);
+      SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, ex.getMessage(), () -> new MojoExecutionException(ex.getMessage(), ex));
     }
   }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/UndeployMojo.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
-import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.maven.plugin.mojo.ManifestProvider;
 import org.eclipse.jkube.maven.plugin.mojo.build.AbstractJKubeMojo;
 
@@ -29,6 +28,7 @@ import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.plugins.annotations.ResolutionScope;
 
+import static org.eclipse.jkube.kit.config.service.kubernetes.SummaryServiceUtil.handleExceptionAndSummary;
 import static org.eclipse.jkube.maven.plugin.mojo.build.ApplyMojo.DEFAULT_KUBERNETES_MANIFEST;
 
 /**
@@ -71,7 +71,8 @@ public class UndeployMojo extends AbstractJKubeMojo implements ManifestProvider 
     try {
       undeploy();
     } catch (IOException ex) {
-      SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled, ex.getMessage(), () -> new MojoExecutionException(ex.getMessage(), ex));
+      handleExceptionAndSummary(jkubeServiceHub, ex);
+      throw new MojoExecutionException(ex.getMessage(), ex);
     }
   }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojo.java
@@ -28,6 +28,7 @@ import org.eclipse.jkube.kit.common.util.KubernetesHelper;
 import org.eclipse.jkube.kit.common.util.MavenUtil;
 import org.eclipse.jkube.kit.common.util.ResourceUtil;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.common.util.SummaryUtil;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
 import org.eclipse.jkube.kit.enricher.api.util.KubernetesResourceUtil;
 import org.eclipse.jkube.kit.profile.ProfileUtil;
@@ -112,9 +113,11 @@ public class WatchMojo extends AbstractDockerMojo implements ManifestProvider {
                 context);
 
         } catch (KubernetesClientException ex) {
-            KubernetesResourceUtil.handleKubernetesClientException(ex, this.log);
+            KubernetesResourceUtil.handleKubernetesClientException(ex, this.log, summaryEnabled);
         } catch (Exception ex) {
-            throw new MojoExecutionException("An error has occurred while while trying to watch the resources", ex);
+            SummaryUtil.setFailureIfSummaryEnabledOrThrow(summaryEnabled,
+                ex.getMessage(),
+                () -> new MojoExecutionException("An error has occurred while while trying to watch the resources", ex));
         }
     }
 

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojoFailureScenariosTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojoFailureScenariosTest.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.maven.plugin.mojo.build;
+
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.openshift.client.NamespacedOpenShiftClient;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.settings.Settings;
+import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.util.KubernetesHelper;
+import org.eclipse.jkube.kit.config.service.ApplyService;
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedStatic;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+class ApplyMojoFailureScenariosTest {
+
+  private JKubeServiceHub mockedJKubeServiceHub;
+  private MockedStatic<KubernetesHelper> kubernetesHelperMockedStatic;
+  private File kubernetesManifestFile;
+  private ApplyService mockedApplyService;
+
+  private ApplyMojo applyMojo;
+
+  @BeforeEach
+  void setUp(@TempDir Path temporaryFolder) throws IOException {
+    mockedApplyService = mock(ApplyService.class);
+    kubernetesHelperMockedStatic = mockStatic(KubernetesHelper.class);
+    kubernetesHelperMockedStatic.when(KubernetesHelper::getDefaultNamespace).thenReturn("default");
+    kubernetesManifestFile = Files.createFile(temporaryFolder.resolve("kubernetes.yml")).toFile();
+    NamespacedOpenShiftClient defaultKubernetesClient = mock(NamespacedOpenShiftClient.class);
+    when(defaultKubernetesClient.adapt(any())).thenReturn(defaultKubernetesClient);
+    when(defaultKubernetesClient.getMasterUrl()).thenReturn(URI.create("https://www.example.com").toURL());
+    mockedJKubeServiceHub = mock(JKubeServiceHub.class, RETURNS_DEEP_STUBS);
+    when(mockedJKubeServiceHub.getApplyService()).thenReturn(mockedApplyService);
+    when(mockedJKubeServiceHub.getClient()).thenReturn(defaultKubernetesClient);
+    // @formatter:off
+    applyMojo = new ApplyMojo() {{
+      jkubeServiceHub = mockedJKubeServiceHub;
+      settings = mock(Settings.class);
+      kubernetesManifest = kubernetesManifestFile;
+      log = new KitLogger.SilentLogger();
+    }};
+    // @formatter:on
+  }
+
+  @AfterEach
+  void tearDown() {
+    kubernetesHelperMockedStatic.close();
+    applyMojo = null;
+  }
+
+  @Test
+  void executeInternal_whenApplyServiceFailsToApplyManifests_thenThrowException() {
+    // Given
+    doThrow(new KubernetesClientException("kubernetes failure"))
+        .when(mockedApplyService).applyEntities(anyString(), anyCollection(), any(), anyLong());
+
+    // When + Then
+    assertThatIllegalStateException()
+        .isThrownBy(() -> applyMojo.executeInternal())
+        .withMessage("kubernetes failure");
+  }
+
+  @Test
+  void executeInternal_whenManifestLoadFailure_thenThrowException() {
+      // Given
+      kubernetesHelperMockedStatic.when(() -> KubernetesHelper.loadResources(any()))
+          .thenThrow(new IOException("failure in loading manifests"));
+
+      // When + Then
+      assertThatExceptionOfType(MojoExecutionException.class)
+          .isThrownBy(() -> applyMojo.executeInternal())
+          .withMessage("failure in loading manifests");
+  }
+
+}

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ApplyMojoTest.java
@@ -25,6 +25,7 @@ import io.fabric8.openshift.client.NamespacedOpenShiftClient;
 import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.service.ApplyService;
@@ -63,11 +64,12 @@ class ApplyMojoTest {
 
   @BeforeEach
   void setUp(@TempDir Path temporaryFolder) throws IOException {
+    SummaryService summaryService = mock(SummaryService.class);
     jKubeServiceHubMockedConstruction = mockConstruction(JKubeServiceHub.class,
         withSettings().defaultAnswer(RETURNS_DEEP_STUBS), (mock, context) -> {
           when(mock.getClient()).thenReturn(defaultKubernetesClient);
           when(mock.getClusterAccess().createDefaultClient()).thenReturn(defaultKubernetesClient);
-          when(mock.getApplyService()).thenReturn(new ApplyService(defaultKubernetesClient, new KitLogger.SilentLogger()));
+          when(mock.getApplyService()).thenReturn(new ApplyService(defaultKubernetesClient, new KitLogger.SilentLogger(), summaryService));
         });
     clusterAccessMockedConstruction = mockConstruction(ClusterAccess.class, (mock, context) ->
         when(mock.getNamespace()).thenAnswer(invocation -> kubeConfigNamespace));

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/BuildMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/BuildMojoTest.java
@@ -13,33 +13,167 @@
  */
 package org.eclipse.jkube.maven.plugin.mojo.build;
 
+import org.apache.maven.artifact.DependencyResolutionRequiredException;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.project.MavenProject;
+import org.apache.maven.settings.Settings;
+import org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory;
+import org.eclipse.jkube.kit.build.service.docker.access.DockerAccess;
+import org.eclipse.jkube.kit.build.service.docker.config.handler.ImageConfigResolver;
+import org.eclipse.jkube.kit.common.JKubeConfiguration;
+import org.eclipse.jkube.kit.common.JavaProject;
+import org.eclipse.jkube.kit.common.service.SummaryService;
+import org.eclipse.jkube.kit.common.util.MavenUtil;
+import org.eclipse.jkube.kit.config.image.ImageConfiguration;
+import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.OpenshiftBuildConfig;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
+import org.eclipse.jkube.kit.config.service.BuildService;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
+import org.eclipse.jkube.kit.config.service.JKubeServiceException;
+import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class BuildMojoTest {
-    private MavenProject mavenProject;
+    private DockerAccessFactory mockedDockerAccessFactory;
+    private MavenProject mockedMavenProject;
+    private Settings mockedMavenSettings;
+    private BuildMojo buildMojo;
+    private BuildService mockedBuildService;
+    private List<ImageConfiguration> imageConfigurationList;
+    private MockedStatic<MavenUtil> mavenUtilMockedStatic;
+    private MockedConstruction<JKubeServiceHub> jKubeServiceHubMockedConstruction;
+    @TempDir
+    private File temporaryFolder;
+
     @BeforeEach
     void setUp() {
-        mavenProject = mock(MavenProject.class,RETURNS_DEEP_STUBS);
-        when(mavenProject.getBuild().getDirectory()).thenReturn("target");
+        imageConfigurationList = Collections.singletonList(ImageConfiguration.builder()
+            .name("test/foo:latest")
+            .build(BuildConfiguration.builder()
+                .from("test/base:latest")
+                .build())
+            .build());
+        mockedDockerAccessFactory = mock(DockerAccessFactory.class);
+        ImageConfigResolver mockedImageConfigResolver = mock(ImageConfigResolver.class);
+        MojoExecution mockedMojoExecution = mock(MojoExecution.class);
+        MavenSession mockedMavenSession = mock(MavenSession.class);
+        JavaProject mockedJavaProject = mock(JavaProject.class);
+        JKubeConfiguration mockedJKubeConfiguration = mock(JKubeConfiguration.class);
+        SummaryService mockedSummaryService = mock(SummaryService.class);
+        mockedMavenProject = mock(MavenProject.class, RETURNS_DEEP_STUBS);
+        mockedMavenSettings = mock(Settings.class, RETURNS_DEEP_STUBS);
+        mockedBuildService = mock(BuildService.class);
+        mavenUtilMockedStatic = mockStatic(MavenUtil.class);
+        jKubeServiceHubMockedConstruction = mockConstruction(JKubeServiceHub.class, (mock, ctx) -> {
+            when(mock.getBuildService()).thenReturn(mockedBuildService);
+            when(mock.getConfiguration()).thenReturn(mockedJKubeConfiguration);
+            when(mock.getSummaryService()).thenReturn(mockedSummaryService);
+        });
+        mavenUtilMockedStatic.when(() -> MavenUtil.convertMavenProjectToJKubeProject(any(), any()))
+            .thenReturn(mockedJavaProject);
+        when(mockedDockerAccessFactory.createDockerAccess(any())).thenReturn(mock(DockerAccess.class));
+        when(mockedMavenProject.getPackaging()).thenReturn("jar");
+        when(mockedMavenProject.getBuild().getDirectory()).thenReturn(temporaryFolder.getAbsolutePath());
+        when(mockedJKubeConfiguration.getProject()).thenReturn(mockedJavaProject);
+        when(mockedJavaProject.getProperties()).thenReturn(new Properties());
+        buildMojo = new BuildMojo() {{
+            dockerAccessFactory = mockedDockerAccessFactory;
+            imageConfigResolver = mockedImageConfigResolver;
+            project = mockedMavenProject;
+            settings = mockedMavenSettings;
+            session = mockedMavenSession;
+            mojoExecution = mockedMojoExecution;
+        }};
+    }
+
+    @AfterEach
+    void tearDown() {
+        mavenUtilMockedStatic.close();
+        jKubeServiceHubMockedConstruction.close();
+    }
+
+    @Test
+    void execute_withImageConfiguration_shouldDelegateToBuildService() throws Exception {
+        // Given
+        buildMojo.resolvedImages = imageConfigurationList;
+
+        // When
+        buildMojo.execute();
+
+        // Then
+        assertThat(jKubeServiceHubMockedConstruction.constructed()).isNotEmpty();
+        verify(mockedBuildService).build(any());
+        verify(mockedBuildService).postProcess();
+    }
+
+    @Test
+    void execute_withPomPackagingAndSkipBuildPom_shouldDoNothing() throws Exception {
+        // Given
+        buildMojo.resolvedImages = imageConfigurationList;
+        buildMojo.skipBuildPom = true;
+        when(mockedMavenProject.getPackaging()).thenReturn("pom");
+
+        // When
+        buildMojo.execute();
+
+        // Then
+        verify(mockedBuildService, times(0)).build(any());
+    }
+
+    @Test
+    void execute_whenBuildServiceFails_thenThrowException() throws Exception {
+        // Given
+        doThrow(new JKubeServiceException("failure in build"))
+            .when(mockedBuildService).build(any());
+
+        // When + Then
+        assertThatExceptionOfType(MojoExecutionException.class)
+            .isThrownBy(() -> buildMojo.execute())
+            .withMessage("Failed to execute the build");
+    }
+
+    @Test
+    void execute_whenFailureInInitializingProject_thenThrowException() {
+        // Given
+        DependencyResolutionRequiredException dependencyResolutionRequiredException = mock(DependencyResolutionRequiredException.class);
+        when(dependencyResolutionRequiredException.getMessage()).thenReturn("Attempted to access the artifact foo; which has not yet been resolved");
+        mavenUtilMockedStatic.when(() -> MavenUtil.convertMavenProjectToJKubeProject(any(), any()))
+                .thenThrow(dependencyResolutionRequiredException);
+
+        // When + Then
+        assertThatExceptionOfType(MojoExecutionException.class)
+            .isThrownBy(() -> buildMojo.execute())
+            .withMessage("Attempted to access the artifact foo; which has not yet been resolved");
     }
 
     @Test
     void buildServiceConfigBuilder_shouldReturnNonNullResourceConfigIfConfigured() {
         // Given
-        BuildMojo buildMojo = new BuildMojo();
-        buildMojo.project = mavenProject;
         buildMojo.resources = ResourceConfig.builder()
                 .openshiftBuildConfig(OpenshiftBuildConfig.builder()
                         .limit("cpu", "200m")

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmMojoTest.java
@@ -21,6 +21,8 @@ import java.util.Arrays;
 
 import io.fabric8.kubernetes.api.model.ConfigMapBuilder;
 import io.fabric8.kubernetes.api.model.KubernetesListBuilder;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.settings.Settings;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
 import org.eclipse.jkube.kit.common.KitLogger;
@@ -61,6 +63,12 @@ class HelmMojoTest {
 
   @TempDir
   private Path projectDir;
+  private MavenProject mavenProject;
+  private MojoExecution mojoExecution;
+  private MavenSession mavenSession;
+  private JKubeServiceHub jKubeServiceHub;
+  private HelmService helmService;
+
   private HelmMojo helmMojo;
   private MockedStatic<ResourceUtil> resourceUtilMockedStatic;
 
@@ -134,7 +142,7 @@ class HelmMojoTest {
   @Test
   void executeInternal_withNoConfigGenerateThrowsException_shouldRethrowWithMojoExecutionException() {
     try (MockedConstruction<HelmService> helmServiceMockedConstruction = mockConstruction(HelmService.class,
-      (mock, ctx) -> doThrow(new IOException("Exception is thrown")).when(mock).generateHelmCharts(any())
+        (mock, ctx) -> doThrow(new IOException("Exception is thrown")).when(mock).generateHelmCharts(any())
     )) {
       // When & Then
       assertThatExceptionOfType(MojoExecutionException.class)

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmPushMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmPushMojoTest.java
@@ -14,6 +14,7 @@
 package org.eclipse.jkube.maven.plugin.mojo.build;
 
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 
@@ -43,6 +44,7 @@ import org.mockito.AdditionalAnswers;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -63,7 +65,7 @@ class HelmPushMojoTest {
   void setUp() throws Exception {
     helmPushMojo = new HelmPushMojo();
     mavenSession = mock(MavenSession.class);
-    mojoExecution = mock(MojoExecution.class);
+    mojoExecution = mock(MojoExecution.class, RETURNS_DEEP_STUBS);
     helmPushMojo.helm = new HelmConfig();
     helmPushMojo.project = new MavenProject();
     helmPushMojo.session = mavenSession;
@@ -74,9 +76,9 @@ class HelmPushMojoTest {
       .setOutputDirectory(projectDir.resolve("target").resolve("classes").toFile().getAbsolutePath());
     helmPushMojo.project.getBuild().setDirectory(projectDir.resolve("target").toFile().getAbsolutePath());
     helmPushMojo.project.setFile(projectDir.resolve("target").toFile());
-    helmPushMojo.mojoExecution.getMojoDescriptor().setPluginDescriptor(new PluginDescriptor());
-    helmPushMojo.mojoExecution.getMojoDescriptor().getPluginDescriptor().setGoalPrefix("k8s");
-    helmPushMojo.mojoExecution.getMojoDescriptor().setGoal("helm-push");
+    when(mojoExecution.getMojoDescriptor().getFullGoalName()).thenReturn("k8s:helm-push");
+    when(mavenSession.getGoals()).thenReturn(Collections.singletonList("k8s:helm-push"));
+    when(mojoExecution.getGoal()).thenReturn("k8s:helm-push");
     when(helmPushMojo.securityDispatcher.decrypt(anyString()))
       .thenReturn(String.valueOf(AdditionalAnswers.returnsFirstArg()));
   }

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojoTest.java
@@ -50,7 +50,6 @@ import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.inOrder;
@@ -143,7 +142,7 @@ class ResourceMojoTest {
         .isEqualTo("jkube/test-project");
     verify(mockedJKubeServiceHub, times(2)).getResourceService();
     verify(mockedResourceService, times(1)).generateResources(eq(PlatformMode.kubernetes), any(), any());
-    verify(mockedResourceService, times(1)).writeResources(any(), eq(ResourceClassifier.KUBERNETES), any());
+    verify(mockedResourceService, times(1)).writeResources(any(), eq(ResourceClassifier.KUBERNETES), any(), any());
   }
 
   @Test
@@ -158,7 +157,7 @@ class ResourceMojoTest {
     assertThat(defaultEnricherManagerMockedConstruction.constructed()).isEmpty();
     verify(mockedJKubeServiceHub, times(0)).getResourceService();
     verify(mockedResourceService, times(0)).generateResources(any(), any(), any());
-    verify(mockedResourceService, times(0)).writeResources(any(), any(), any());
+    verify(mockedResourceService, times(0)).writeResources(any(), any(), any(), any());
   }
 
   @Test
@@ -173,7 +172,7 @@ class ResourceMojoTest {
     assertThat(defaultEnricherManagerMockedConstruction.constructed()).isEmpty();
     verify(mockedJKubeServiceHub, times(0)).getResourceService();
     verify(mockedResourceService, times(0)).generateResources(any(), any(), any());
-    verify(mockedResourceService, times(0)).writeResources(any(), any(), any());
+    verify(mockedResourceService, times(0)).writeResources(any(), any(), any(), any());
   }
 
   @Test
@@ -188,7 +187,7 @@ class ResourceMojoTest {
       assertThat(resourceValidatorMockedConstruction.constructed()).hasSize(1);
       ResourceValidator mockResourceValidator = resourceValidatorMockedConstruction.constructed().get(0);
       InOrder inOrder = inOrder(mockedResourceService, mockResourceValidator);
-      inOrder.verify(mockedResourceService).writeResources(any(), any(), any());
+      inOrder.verify(mockedResourceService).writeResources(any(), any(), any(), any());
       inOrder.verify(mockResourceValidator).validate();
     }
   }

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/ResourceMojoTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.maven.plugin.mojo.build;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -49,6 +50,7 @@ import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.inOrder;
@@ -72,10 +74,12 @@ class ResourceMojoTest {
     ImageConfigResolver mockedImageConfigResolver = mock(ImageConfigResolver.class, RETURNS_DEEP_STUBS);
     Properties properties = new Properties();
     MavenProject mockedMavenProject = mock(MavenProject.class, RETURNS_DEEP_STUBS);
+    MavenSession mockedMavenSession = mock(MavenSession.class);
     mockedResourceService = mock(ResourceService.class, RETURNS_DEEP_STUBS);
     MojoExecution mockedMojoExecution = mock(MojoExecution.class, RETURNS_DEEP_STUBS);
     MojoDescriptor mockedMojoDescriptor = mock(MojoDescriptor.class, RETURNS_DEEP_STUBS);
     when(mockedMojoExecution.getMojoDescriptor()).thenReturn(mockedMojoDescriptor);
+    when(mockedMojoExecution.getGoal()).thenReturn("k8s:resource");
     when(mockedMojoDescriptor.getFullGoalName()).thenReturn("k8s:resource");
     defaultEnricherManagerMockedConstruction = mockConstruction(DefaultEnricherManager.class);
     JavaProject javaProject = JavaProject.builder()
@@ -99,6 +103,7 @@ class ResourceMojoTest {
     this.resourceMojo.images = Collections.singletonList(imageConfiguration);
     this.resourceMojo.project = mockedMavenProject;
     this.resourceMojo.settings = mock(Settings.class, RETURNS_DEEP_STUBS);
+    this.resourceMojo.session = mockedMavenSession;
     this.resourceMojo.jkubeServiceHub = mockedJKubeServiceHub;
     this.resourceMojo.log = mock(KitLogger.class, RETURNS_DEEP_STUBS);
     this.resourceMojo.skipResourceValidation = true;
@@ -110,6 +115,7 @@ class ResourceMojoTest {
     resourceMojo.mojoExecution = mockedMojoExecution;
 
     when(mockedMavenProject.getProperties()).thenReturn(properties);
+    when(mockedMavenSession.getGoals()).thenReturn(Collections.singletonList("k8s:resource"));
     when(mockedJKubeServiceHub.getConfiguration().getProject()).thenReturn(javaProject);
     when(mockedJKubeServiceHub.getConfiguration().getBasedir()).thenReturn(temporaryFolder.toFile());
     when(mockedJKubeServiceHub.getResourceService()).thenReturn(mockedResourceService);

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/SkipGoalsTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/SkipGoalsTest.java
@@ -13,6 +13,7 @@
  */
 package org.eclipse.jkube.maven.plugin.mojo.build;
 
+import org.apache.maven.execution.MavenSession;
 import org.apache.maven.plugin.MojoExecution;
 import org.eclipse.jkube.kit.common.KitLogger;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,6 +22,8 @@ import org.mockito.Answers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
+
+import java.util.Collections;
 
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
@@ -35,6 +38,9 @@ class SkipGoalsTest {
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private MojoExecution mojoExecution;
+
+    @Mock
+    private MavenSession mavenSession;
 
     @Spy
     @InjectMocks
@@ -82,6 +88,7 @@ class SkipGoalsTest {
       doNothing().when(applyMojo).init();
       doNothing().when(applyMojo).executeInternal();
       when(mojoExecution.getMojoDescriptor().getFullGoalName()).thenReturn("k8s:apply");
+      when(mavenSession.getGoals()).thenReturn(Collections.singletonList("k8s:apply"));
     }
 
     @Test

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/DebugMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/DebugMojoTest.java
@@ -17,8 +17,11 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.Properties;
 
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
 import org.eclipse.jkube.kit.common.util.AnsiLogger;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
@@ -52,6 +55,8 @@ class DebugMojoTest {
   private MockedConstruction<ClusterAccess> clusterAccessMockedConstruction;
   private File kubernetesManifestFile;
   private MavenProject mavenProject;
+  private MavenSession mavenSession;
+  private MojoExecution mockedMojoExecution;
 
   private DebugMojo debugMojo;
 
@@ -66,10 +71,16 @@ class DebugMojoTest {
     clusterAccessMockedConstruction = mockConstruction(ClusterAccess.class);
     kubernetesManifestFile = Files.createFile(temporaryFolder.resolve("kubernetes.yml")).toFile();
     mavenProject = mock(MavenProject.class);
+    mavenSession = mock(MavenSession.class);
+    mockedMojoExecution = mock(MojoExecution.class);
     when(mavenProject.getProperties()).thenReturn(new Properties());
+    when(mavenSession.getGoals()).thenReturn(Collections.singletonList("k8s:debug"));
+    when(mockedMojoExecution.getGoal()).thenReturn("k8s:debug");
     // @formatter:off
     debugMojo = new DebugMojo() { {
       project = mavenProject;
+      session = mavenSession;
+      mojoExecution = mockedMojoExecution;
       settings = mock(Settings.class);
       kubernetesManifest = kubernetesManifestFile;
     }};

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/LogMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/LogMojoTest.java
@@ -15,10 +15,14 @@ package org.eclipse.jkube.maven.plugin.mojo.develop;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.Properties;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.openshift.client.OpenShiftClient;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 import org.eclipse.jkube.kit.config.service.PodLogService;
@@ -52,7 +56,8 @@ class LogMojoTest {
   private MockedConstruction<PodLogService> podLogServiceMockedConstruction;
   private File kubernetesManifestFile;
   private MavenProject mavenProject;
-
+  private MavenSession mockedMavenSession;
+  private MojoExecution mockedMojoExecution;
   private LogMojo logMojo;
 
   @BeforeEach
@@ -67,10 +72,16 @@ class LogMojoTest {
     podLogServiceMockedConstruction = mockConstruction(PodLogService.class);
     kubernetesManifestFile = File.createTempFile("kubernetes", ".yml", temporaryFolder);
     mavenProject = mock(MavenProject.class);
+    mockedMavenSession = mock(MavenSession.class);
+    mockedMojoExecution = mock(MojoExecution.class);
     when(mavenProject.getProperties()).thenReturn(new Properties());
+    when(mockedMavenSession.getGoals()).thenReturn(Arrays.asList("k8s:log", "k8s:apply"));
+    when(mockedMojoExecution.getGoal()).thenReturn("k8s:log");
     // @formatter:off
     logMojo = new LogMojo() { {
       project = mavenProject;
+      session = mockedMavenSession;
+      mojoExecution = mockedMojoExecution;
       settings = mock(Settings.class);
       kubernetesManifest = kubernetesManifestFile;
     }};

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/RemoteDevMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/RemoteDevMojoTest.java
@@ -13,6 +13,8 @@
  */
 package org.eclipse.jkube.maven.plugin.mojo.develop;
 
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecution;
 import org.apache.maven.project.MavenProject;
 import org.apache.maven.settings.Settings;
 import org.eclipse.jkube.kit.remotedev.RemoteDevelopmentService;
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 
+import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 
@@ -43,10 +46,16 @@ class RemoteDevMojoTest {
   @BeforeEach
   void setUp() {
     final MavenProject mavenProject = mock(MavenProject.class);
+    final MavenSession mavenSession = mock(MavenSession.class);
+    final MojoExecution mavenMojoExecution = mock(MojoExecution.class);
+    when(mavenSession.getGoals()).thenReturn(Collections.singletonList("k8s:remote-dev"));
+    when(mavenMojoExecution.getGoal()).thenReturn("k8s:remote-dev");
     when(mavenProject.getProperties()).thenReturn(new Properties());
     remoteDevMojo = new RemoteDevMojo() {{
       project = mavenProject;
       settings = mock(Settings.class, RETURNS_DEEP_STUBS);
+      mojoExecution = mavenMojoExecution;
+      session = mavenSession;
     }};
     started = new CompletableFuture<>();
     remoteDevelopmentService = mockConstruction(RemoteDevelopmentService.class, (mock, ctx) ->

--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/develop/WatchMojoTest.java
@@ -22,6 +22,7 @@ import org.eclipse.jkube.kit.build.service.docker.DockerAccessFactory;
 import org.eclipse.jkube.kit.build.service.docker.config.handler.ImageConfigResolver;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
+import org.eclipse.jkube.kit.common.service.SummaryService;
 import org.eclipse.jkube.kit.config.access.ClusterAccess;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
 import org.eclipse.jkube.kit.config.service.ApplyService;
@@ -72,8 +73,9 @@ class WatchMojoTest {
     mockedJavaProject = mock(JavaProject.class);
     mockedClusterAccess = mock(ClusterAccess.class);
     watcherManagerMockedStatic = mockStatic(WatcherManager.class);
+    SummaryService mockedSummaryService = mock(SummaryService.class);
 
-    when(mockedJKubeServiceHub.getApplyService()).thenReturn(new ApplyService(mockKubernetesClient, new KitLogger.SilentLogger()));
+    when(mockedJKubeServiceHub.getApplyService()).thenReturn(new ApplyService(mockKubernetesClient, new KitLogger.SilentLogger(), mockedSummaryService));
     when(mockedJavaProject.getProperties()).thenReturn(new Properties());
     when(mavenProject.getArtifactId()).thenReturn("artifact-id");
     when(mavenProject.getVersion()).thenReturn("1337");


### PR DESCRIPTION
## Description

Fixes #1033

Add summary for jkube build actions in order to improve ux. Summary is printed for `build`, `push`, `resource`, `helm`, `helm-push`, `apply`, and `undeploy` actions. 

Added a `Summary` and `SummaryService` class which creates a temporary file storing state of Summary object as control goes from different parts of codebase. Both in case of maven and gradle, it's being checked whether current goal/task is last executing task and then only summary is being printed.  

Right now basic details are printed after small jkube banner. This output can be changed as per requirements:

```
[INFO] k8s:  __ / / //_/ / / / _ )/ __/
[INFO] k8s: / // / ,< / /_/ / _  / _/  
[INFO] k8s: \___/_/|_|\____/____/___/  

[INFO] k8s: -------------------------------
[INFO] k8s:       SUMMARY
[INFO] k8s: -------------------------------
[INFO] k8s: Container images:
[INFO] k8s:  - maven/external-resources:latest
[INFO] k8s:     * Base image: quay.io/jkube/jkube-java:0.0.16
[INFO] k8s:     * SHA: sha256:f63f0
[INFO] k8s: 
[INFO] k8s: Build Strategy : Local Docker
[INFO] k8s: Generators applied: [spring-boot]
[INFO] k8s: 
[INFO] k8s: Enrichers applied: [jkube-dependency,jkube-controller,jkube-controller-from-configuration,jkube-service,jkube-image,jkube-portname,jkube-project-label,jkube-git,jkube-maven-scm,jkube-serviceaccount,jkube-configmap-file,jkube-healthcheck-spring-boot,jkube-prometheus,jkube-revision-history,jkube-name,jkube-metadata,jkube-pod-annotations,jkube-container-env-java-options]
[INFO] k8s: Generated resources:
[INFO] k8s:  - target/classes/META-INF/jkube/kubernetes/external-resources-service.yml
[INFO] k8s:  - target/classes/META-INF/jkube/kubernetes/game-config-env-file-configmap.yml
[INFO] k8s:  - target/classes/META-INF/jkube/kubernetes/second-configmap.yml
[INFO] k8s:  - target/classes/META-INF/jkube/kubernetes/external-resources-deployment.yml
[INFO] k8s:  - target/classes/META-INF/jkube/kubernetes.yml
[INFO] k8s: 
[INFO] k8s: Applied resources from https://api.sandbox.x8i5.p1.openshiftapps.com:6443/
[INFO] k8s:  - external-resources
[INFO] k8s:    * v1 Service
[INFO] k8s:    * Namespace: rokumar-dev
[INFO] k8s:  - game-config-env-file
[INFO] k8s:    * v1 ConfigMap
[INFO] k8s:    * Namespace: rokumar-dev
[INFO] k8s:  - second
[INFO] k8s:    * v1 ConfigMap
[INFO] k8s:    * Namespace: rokumar-dev
[INFO] k8s:  - external-resources
[INFO] k8s:    * apps/v1 Deployment
[INFO] k8s:    * Namespace: rokumar-dev
[INFO] k8s: 
[INFO] k8s: -------------------------------
[INFO] k8s: SUCCESS
[INFO] k8s: -------------------------------
```

Signed-off-by: Rohan Kumar <rohaan@redhat.com>




## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [X] Feature (non-breaking change which adds functionality)
 - [X] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [X] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
