### PR TITLE
OpenShift route generator: prefer port name over port number for Route's `targetPort` when it's possible

### DIFF
--- a/gradle-plugin/it/src/it/autotls/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/autotls/expected/openshift.yml
@@ -142,7 +142,7 @@ items:
       name: autotls
     spec:
       port:
-        targetPort: 8080
+        targetPort: http
       to:
         kind: Service
         name: autotls

--- a/gradle-plugin/it/src/it/dockerfile-simple/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/dockerfile-simple/expected/openshift.yml
@@ -89,7 +89,7 @@ items:
     name: dockerfile-simple
   spec:
     port:
-      targetPort: 9080
+      targetPort: glrpc
     to:
       kind: Service
       name: dockerfile-simple

--- a/gradle-plugin/it/src/it/expose/expected/ftp-port-expose-annotation-enricher/openshift.yml
+++ b/gradle-plugin/it/src/it/expose/expected/ftp-port-expose-annotation-enricher/openshift.yml
@@ -134,7 +134,7 @@ items:
     name: expose
   spec:
     port:
-      targetPort: 21
+      targetPort: ftp
     to:
       kind: Service
       name: expose

--- a/gradle-plugin/it/src/it/expose/expected/ftp-port-expose-annotation/openshift.yml
+++ b/gradle-plugin/it/src/it/expose/expected/ftp-port-expose-annotation/openshift.yml
@@ -134,7 +134,7 @@ items:
     name: expose
   spec:
     port:
-      targetPort: 21
+      targetPort: ftp
     to:
       kind: Service
       name: expose

--- a/gradle-plugin/it/src/it/expose/expected/ftp-port-external/openshift.yml
+++ b/gradle-plugin/it/src/it/expose/expected/ftp-port-external/openshift.yml
@@ -132,7 +132,7 @@ items:
     name: expose
   spec:
     port:
-      targetPort: 21
+      targetPort: ftp
     to:
       kind: Service
       name: expose

--- a/gradle-plugin/it/src/it/expose/expected/http-port-external/openshift.yml
+++ b/gradle-plugin/it/src/it/expose/expected/http-port-external/openshift.yml
@@ -132,7 +132,7 @@ items:
     name: expose
   spec:
     port:
-      targetPort: 80
+      targetPort: http
     to:
       kind: Service
       name: expose

--- a/gradle-plugin/it/src/it/expose/expected/http-port/openshift.yml
+++ b/gradle-plugin/it/src/it/expose/expected/http-port/openshift.yml
@@ -132,7 +132,7 @@ items:
     name: expose
   spec:
     port:
-      targetPort: 80
+      targetPort: http
     to:
       kind: Service
       name: expose

--- a/gradle-plugin/it/src/it/expose/expected/multiple-services/openshift.yml
+++ b/gradle-plugin/it/src/it/expose/expected/multiple-services/openshift.yml
@@ -230,7 +230,7 @@ items:
     name: expose
   spec:
     port:
-      targetPort: 443
+      targetPort: https
     to:
       kind: Service
       name: expose
@@ -256,7 +256,7 @@ items:
     name: ssh
   spec:
     port:
-      targetPort: 22
+      targetPort: ssh
     to:
       kind: Service
       name: ssh

--- a/gradle-plugin/it/src/it/helidon/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/helidon/expected/openshift.yml
@@ -137,7 +137,7 @@ items:
     name: helidon
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: helidon

--- a/gradle-plugin/it/src/it/image-pull-secrets/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/image-pull-secrets/expected/openshift.yml
@@ -135,7 +135,7 @@ items:
       name: image-pull-secrets
     spec:
       port:
-        targetPort: 8080
+        targetPort: http
       to:
         kind: Service
         name: image-pull-secrets

--- a/gradle-plugin/it/src/it/initcontainers/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/initcontainers/expected/openshift.yml
@@ -126,7 +126,7 @@ items:
       name: initcontainers
     spec:
       port:
-        targetPort: 8080
+        targetPort: http
       to:
         kind: Service
         name: initcontainers

--- a/gradle-plugin/it/src/it/metadata/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/metadata/expected/openshift.yml
@@ -156,7 +156,7 @@ items:
     name: metadata
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: metadata

--- a/gradle-plugin/it/src/it/multiple-services/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/multiple-services/expected/openshift.yml
@@ -179,7 +179,7 @@ items:
     name: multiple-services
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: multiple-services

--- a/gradle-plugin/it/src/it/openliberty/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/openliberty/expected/openshift.yml
@@ -137,7 +137,7 @@ items:
     name: openliberty
   spec:
     port:
-      targetPort: 9080
+      targetPort: glrpc
     to:
       kind: Service
       name: openliberty

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/liveness-readiness/openshift.yml
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/liveness-readiness/openshift.yml
@@ -151,7 +151,7 @@ items:
     name: probes-groovy-dsl-config
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: probes-groovy-dsl-config

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/none/openshift.yml
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/none/openshift.yml
@@ -119,7 +119,7 @@ items:
     name: probes-groovy-dsl-config
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: probes-groovy-dsl-config

--- a/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/startup/openshift.yml
+++ b/gradle-plugin/it/src/it/probes-groovy-dsl-config/expected/startup/openshift.yml
@@ -127,7 +127,7 @@ items:
     name: probes-groovy-dsl-config
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: probes-groovy-dsl-config

--- a/gradle-plugin/it/src/it/project-label/expected/app/openshift.yml
+++ b/gradle-plugin/it/src/it/project-label/expected/app/openshift.yml
@@ -110,7 +110,7 @@ items:
     name: project-label
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: project-label

--- a/gradle-plugin/it/src/it/project-label/expected/custom/openshift.yml
+++ b/gradle-plugin/it/src/it/project-label/expected/custom/openshift.yml
@@ -109,7 +109,7 @@ items:
     name: project-label
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: project-label

--- a/gradle-plugin/it/src/it/project-label/expected/default/openshift.yml
+++ b/gradle-plugin/it/src/it/project-label/expected/default/openshift.yml
@@ -109,7 +109,7 @@ items:
     name: project-label
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: project-label

--- a/gradle-plugin/it/src/it/project-label/expected/group/openshift.yml
+++ b/gradle-plugin/it/src/it/project-label/expected/group/openshift.yml
@@ -109,7 +109,7 @@ items:
     name: project-label
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: project-label

--- a/gradle-plugin/it/src/it/project-label/expected/version/openshift.yml
+++ b/gradle-plugin/it/src/it/project-label/expected/version/openshift.yml
@@ -109,7 +109,7 @@ items:
     name: project-label
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: project-label

--- a/gradle-plugin/it/src/it/route-name-fragment/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/route-name-fragment/expected/openshift.yml
@@ -110,7 +110,7 @@ items:
     name: customized-name
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: customized-name

--- a/gradle-plugin/it/src/it/route/expected/routeEnabled/openshift.yml
+++ b/gradle-plugin/it/src/it/route/expected/routeEnabled/openshift.yml
@@ -110,7 +110,7 @@ items:
     name: route
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: route

--- a/gradle-plugin/it/src/it/service-name-fragment/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/service-name-fragment/expected/openshift.yml
@@ -106,7 +106,7 @@ items:
     name: customized-name
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: customized-name

--- a/gradle-plugin/it/src/it/service-name/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/service-name/expected/openshift.yml
@@ -106,7 +106,7 @@ items:
     name: customized-name
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: customized-name

--- a/gradle-plugin/it/src/it/service/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/service/expected/openshift.yml
@@ -133,7 +133,7 @@ items:
     name: svc1
   spec:
     port:
-      targetPort: 8080
+      targetPort: port1
     to:
       kind: Service
       name: svc1

--- a/gradle-plugin/it/src/it/smallrye-health/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/smallrye-health/expected/openshift.yml
@@ -137,7 +137,7 @@ items:
     name: smallrye-health
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: smallrye-health

--- a/gradle-plugin/it/src/it/spring-boot-managementhealthprobes/expected/openshift.yml
+++ b/gradle-plugin/it/src/it/spring-boot-managementhealthprobes/expected/openshift.yml
@@ -157,7 +157,7 @@ items:
     name: spring-boot-managementhealthprobes
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: spring-boot-managementhealthprobes

--- a/gradle-plugin/it/src/it/well-known-labels/expected/custom/openshift.yml
+++ b/gradle-plugin/it/src/it/well-known-labels/expected/custom/openshift.yml
@@ -137,7 +137,7 @@ items:
     name: well-known-labels
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: well-known-labels

--- a/gradle-plugin/it/src/it/well-known-labels/expected/default/openshift.yml
+++ b/gradle-plugin/it/src/it/well-known-labels/expected/default/openshift.yml
@@ -131,7 +131,7 @@ items:
     name: well-known-labels
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: well-known-labels

--- a/gradle-plugin/it/src/it/well-known-labels/expected/disabled/openshift.yml
+++ b/gradle-plugin/it/src/it/well-known-labels/expected/disabled/openshift.yml
@@ -109,7 +109,7 @@ items:
     name: well-known-labels
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: well-known-labels

--- a/gradle-plugin/it/src/it/well-known-labels/expected/labelsViaResourceConfig/openshift.yml
+++ b/gradle-plugin/it/src/it/well-known-labels/expected/labelsViaResourceConfig/openshift.yml
@@ -138,7 +138,7 @@ items:
     name: well-known-labels
   spec:
     port:
-      targetPort: 8080
+      targetPort: http
     to:
       kind: Service
       name: well-known-labels

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricher.java
@@ -611,7 +611,7 @@ public class DefaultServiceEnricher extends BaseEnricher {
         return protocol;
     }
 
-    private static ServicePort getServicePortToExpose(ServiceBuilder serviceBuilder){
+    public static ServicePort getServicePortToExpose(ServiceBuilder serviceBuilder){
         ServiceSpec spec = serviceBuilder.buildSpec();
             if (spec != null) {
             final List<ServicePort> ports = spec.getPorts();
@@ -636,13 +636,5 @@ public class DefaultServiceEnricher extends BaseEnricher {
            return  null;
        }
        return servicePort.getPort();
-    }
-
-    public static Integer getTargetPortToExpose(ServiceBuilder serviceBuilder) {
-        ServicePort servicePort = getServicePortToExpose(serviceBuilder);
-        if (servicePort == null || servicePort.getTargetPort() == null){
-            return  null;
-        }
-        return servicePort.getTargetPort().getIntVal();
     }
 }

--- a/openshift-maven-plugin/it/src/it/project/expected/create-project-and-set-different-namespace/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/project/expected/create-project-and-set-different-namespace/openshift.yml
@@ -137,7 +137,7 @@ items:
       namespace: namespace-to-operate
     spec:
       port:
-        targetPort: 8080
+        targetPort: "http"
       to:
         kind: Service
         name: project

--- a/openshift-maven-plugin/it/src/it/project/expected/create-project-and-set-namespace/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/project/expected/create-project-and-set-namespace/openshift.yml
@@ -137,7 +137,7 @@ items:
       namespace: project-to-create-and-operate
     spec:
       port:
-        targetPort: 8080
+        targetPort: "http"
       to:
         kind: Service
         name: project

--- a/openshift-maven-plugin/it/src/it/project/expected/create-project/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/project/expected/create-project/openshift.yml
@@ -134,7 +134,7 @@ items:
       name: project
     spec:
       port:
-        targetPort: 8080
+        targetPort: "http"
       to:
         kind: Service
         name: project

--- a/openshift-maven-plugin/it/src/it/project/expected/default/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/project/expected/default/openshift.yml
@@ -123,7 +123,7 @@ items:
       name: project
     spec:
       port:
-        targetPort: 8080
+        targetPort: "http"
       to:
         kind: Service
         name: project

--- a/openshift-maven-plugin/it/src/it/project/expected/set-namespace/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/project/expected/set-namespace/openshift.yml
@@ -126,7 +126,7 @@ items:
       namespace: namespace-to-operate
     spec:
       port:
-        targetPort: 8080
+        targetPort: "http"
       to:
         kind: Service
         name: project

--- a/openshift-maven-plugin/it/src/it/simple-with-route-flag-true/expected/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/simple-with-route-flag-true/expected/openshift.yml
@@ -122,7 +122,7 @@ items:
     name: jkube-maven-sample-zero-config
   spec:
     port:
-      targetPort: 8080
+      targetPort: "http"
     to:
       kind: Service
       name: jkube-maven-sample-zero-config

--- a/openshift-maven-plugin/it/src/it/statefulset/expected/openshift.yml
+++ b/openshift-maven-plugin/it/src/it/statefulset/expected/openshift.yml
@@ -46,7 +46,7 @@ items:
     name: jkube-maven-sample-statefulset
   spec:
     port:
-      targetPort: 8080
+      targetPort: "http"
     to:
       kind: Service
       name: jkube-maven-sample-statefulset


### PR DESCRIPTION
RouteEnricher gives precedence to Port Name over Port number while setting `targetPort` in [RoutePort](https://github.com/openshift/api/blob/86145edb40cf5c35cf9721ab3459604a316874cf/route/v1/types.go#L340).