### PR TITLE
KubernetesHelper : Replace call to toArray() with a pre-sized array argument with empty array #2837

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -440,7 +440,7 @@ public class KubernetesHelper {
                     log.warn("Ignoring empty values in selector expression %s", expression);
                     continue;
                 }
-                String[] valuesArray = values.toArray(new String[values.size()]);
+                String[] valuesArray = values.toArray(new String[0]);
                 String operator = expression.getOperator();
                 switch (operator) {
                     case "In":

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 2019 Red Hat, Inc.
-    This program and the accompanying materials are made
+    This program and the accompanying materials are mademvn
     available under the terms of the Eclipse Public License 2.0
     which is available at:
 


### PR DESCRIPTION
Fixes #2837

I replaced the pre-sized array of the class with an empty array as proposed.
