### PR TITLE
Remove null check in GitUtil 

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/GitUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/GitUtil.java
@@ -15,7 +15,6 @@ package org.eclipse.jkube.kit.common.util;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Objects;
 import java.util.stream.StreamSupport;
 
 import org.eclipse.jgit.api.Git;
@@ -33,7 +32,7 @@ public class GitUtil {
     private GitUtil() { }
 
     public static Repository getGitRepository(File currentDir) throws IOException {
-        Objects.requireNonNull(currentDir, "currentDir should not be null");
+
         File gitFolder = findGitFolder(currentDir);
         if (gitFolder == null) {
             // No git repository found

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/GitUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/GitUtil.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.kit.common.util;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Objects;
 import java.util.stream.StreamSupport;
 
 import org.eclipse.jgit.api.Git;
@@ -32,11 +33,7 @@ public class GitUtil {
     private GitUtil() { }
 
     public static Repository getGitRepository(File currentDir) throws IOException {
-
-        if (currentDir == null) {
-            // TODO: Why is this check needed ?
-            currentDir = new File(System.getProperty("basedir", "."));
-        }
+        Objects.requireNonNull(currentDir, "currentDir should not be null");
         File gitFolder = findGitFolder(currentDir);
         if (gitFolder == null) {
             // No git repository found


### PR DESCRIPTION
## Description
Removes the null check in `GitUtil.getGitRepository` 
Fixes #2711 


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Breaking change (fix or feature that would cause existing functionality to change
 
## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] New and existing unit tests pass locally with my changes
 - [x] null check is removed from GitUtil
 - [x] passes after making this change
 - [x] [GitAnnotationsIT](https://github.com/eclipse/jkube/blob/master/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/GitAnnotationsIT.java) should pass after making this change

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
