### PR TITLE
fixes Wildfly Generator to accept JKube exception for issue #2931

### DIFF
--- a/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGenerator.java
+++ b/jkube-kit/jkube-kit-wildfly-jar/src/main/java/org/eclipse/jkube/wildfly/jar/generator/WildflyJARGenerator.java
@@ -16,6 +16,7 @@ package org.eclipse.jkube.wildfly.jar.generator;
 import org.eclipse.jkube.generator.api.GeneratorContext;
 import org.eclipse.jkube.generator.javaexec.JavaExecGenerator;
 import org.eclipse.jkube.kit.common.AssemblyFileSet;
+import org.eclipse.jkube.kit.common.JKubeException;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.Plugin;
 import org.eclipse.jkube.kit.common.util.JKubeProjectUtil;
@@ -89,9 +90,10 @@ public class WildflyJARGenerator extends JavaExecGenerator {
                 parentDir = repoDir.getParent();
             }
             if (Files.notExists(repoDir)) {
-               throw new RuntimeException("Error, WildFly bootable JAR generator can't retrieve "
+               throw new JKubeException("Error, WildFly bootable JAR generator can't retrieve "
                        + "generated maven local cache, directory " + repoDir + " doesn't exist.");
             }
+
             set.add(AssemblyFileSet.builder()
                     .directory(parentDir.toFile())
                     .include(localRepoCache.getFileName().toString())


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #2931
Defines and throws a dedicated exception instead of using a generic one in WildflJarGenerator.java 
Uses JKubeException class instead of RuntimeException


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x ] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [ x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ x] My code follows the style guidelines of this project
 - [x ] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [ x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x ] New and existing unit tests pass locally with my changes
 - [ x] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/jkubeio/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
