### PR TITLE
Kushagra/issue#2970

### DIFF
--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/GoTimeUtilTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/GoTimeUtilTest.java
@@ -33,10 +33,7 @@ class GoTimeUtilTest {
     @ParameterizedTest(name = "duration ''{0}'' should be ''{1}'' seconds")
     @MethodSource("data")
     void conversion(String duration, int expectedDuration) {
-        Optional<Integer> optionalResult = GoTimeUtil.durationSeconds(duration);
-        assertThat(optionalResult)
-          .isPresent()
-          .contains(expectedDuration);
+        assertThat(GoTimeUtil.durationSeconds(duration)).isPresent().contains(expectedDuration);
     }
 
     static Stream<Arguments> data() {

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/GoTimeUtilTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/GoTimeUtilTest.java
@@ -21,7 +21,6 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.stream.Stream;
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;

--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/GoTimeUtilTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/api/util/GoTimeUtilTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.stream.Stream;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
@@ -32,8 +33,10 @@ class GoTimeUtilTest {
     @ParameterizedTest(name = "duration ''{0}'' should be ''{1}'' seconds")
     @MethodSource("data")
     void conversion(String duration, int expectedDuration) {
-        int result = GoTimeUtil.durationSeconds(duration).get();
-        assertThat(result).isEqualTo(expectedDuration);
+        Optional<Integer> optionalResult = GoTimeUtil.durationSeconds(duration);
+        assertThat(optionalResult)
+          .isPresent()
+          .contains(expectedDuration);
     }
 
     static Stream<Arguments> data() {


### PR DESCRIPTION
## Description
Refactored GoTimeUtilTest to avoid directly calling Optional.get(). Now, the test checks whether the Optional contains a value before fetching it.

Fixes #2970
- [x] GoTimeUtilTest is refactored to not directly call Optional.get()
- [x] GoTimeUtilTest is passing after making these changes


## Type of change

 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change)
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
 
git config user.name "Kushagra Sinha"
git config user.email "[kushagrasinha123ks@gmail.com](mailto:kushagrasinha123ks@gmail.com)"
git commit --amend --signoff
git push origin kushagra/issue#2970 -f