### PR TITLE
fix (jkube-kit) : Configure YAML_MAPPER to use platform specific line endings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Usage:
 * Fix #2885: Provide a way to set labels on images defined by Generators
 * Fix #2901: Ensure Docker build arguments from properties are used during images pre-pulling
 * Fix #2904: `docker.buildArg.*` properties not taken into account in OpenShift plugins
+* Fix #3007: Kubernetes Maven Plugin generating resource manifests with line feeds on Windows
 
 ### 1.16.2 (2024-03-27)
 * Fix #2461: `k8s:watch`/`k8sWatch` should throw error in `buildpacks` build strategy

--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/Serialization.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/Serialization.java
@@ -37,6 +37,7 @@ public class Serialization {
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();
   private static final ObjectMapper YAML_MAPPER = new ObjectMapper(new YAMLFactory()
     .configure(YAMLGenerator.Feature.MINIMIZE_QUOTES, true)
+    .configure(YAMLGenerator.Feature.USE_PLATFORM_LINE_BREAKS, true)
     .configure(YAMLGenerator.Feature.ALWAYS_QUOTE_NUMBERS_AS_STRINGS, true));
   private static final KubernetesSerialization KUBERNETES_SERIALIZATION = new KubernetesSerialization(JSON_MAPPER, true);
   static {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/SerializationTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/SerializationTest.java
@@ -207,12 +207,12 @@ class SerializationTest {
     // Then
     assertThat(targetFile)
       .content()
-      .isEqualTo("---\n" +
-        "apiVersion: v1\n" +
-        "kind: ConfigMap\n" +
-        "metadata:\n" +
-        "  name: test\n" +
-        "data:\n" +
-        "  key: value\n");
+      .isEqualTo(String.format("---%n" +
+        "apiVersion: v1%n" +
+        "kind: ConfigMap%n" +
+        "metadata:%n" +
+        "  name: test%n" +
+        "data:%n" +
+        "  key: value%n"));
   }
 }


### PR DESCRIPTION
## Description

Fix #3007

Update Serialization's YAML_MAPPER to use line breaks specific to platform it's running on. Earlier we were always using Line Feeds whether on Windows or Unix.



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
