### PR TITLE
fix SpringBootWatcherIntegrationTest on macos

### DIFF
--- a/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/watcher/SpringBootWatcherIntegrationTest.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/watcher/SpringBootWatcherIntegrationTest.java
@@ -120,6 +120,7 @@ class SpringBootWatcherIntegrationTest {
   @Test
   void withAllRequirementsShouldStartWatcherProcess() throws Exception {
     final Runtime runtime = mock(Runtime.class, RETURNS_DEEP_STUBS);
+    target.resolve("spring-boot-lib.jar").toFile().createNewFile();
     target.resolve("spring-boot-devtools.jar").toFile().createNewFile();
     FileUtils.write(target.resolve("application.properties").toFile(), "spring.devtools.remote.secret=this-is-a-test", StandardCharsets.UTF_8);
     new SpringBootWatcher(runtime, watcherContext)
@@ -129,15 +130,19 @@ class SpringBootWatcherIntegrationTest {
       && new File(command[0]).exists()
       && command[1].equals("-cp")
       && command[2].contains(
-      absolutePath("spring-boot-lib.jar") + File.pathSeparator + absolutePath("spring-boot-devtools.jar"))
+      realPath("spring-boot-lib.jar") + File.pathSeparator + realPath("spring-boot-devtools.jar"))
       && command[3].equals("-Dspring.devtools.remote.secret=this-is-a-test")
       && command[4].equals("org.springframework.boot.devtools.RemoteSpringApplication")
       && command[5].matches("^http://localhost:\\d+$")
     ));
   }
 
-  private String absolutePath(String jar) {
-    return project.resolve("target").resolve(jar).toFile().getAbsolutePath();
+  private String realPath(String jar) {
+      try {
+          return project.resolve("target").resolve(jar).toRealPath().toString();
+      } catch (IOException e) {
+          throw new RuntimeException(e);
+      }
   }
 
 }


### PR DESCRIPTION
## Description
In order to fix failing tests on macos, we need to use the real path of jars instead of the absolute path. I.e. we need to use `private/var/folders/...` instead of `/var/folders/...`. Thus, method `absolutePath` is replaced with the `realPath`.

Fixes #3009 

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->