### PR TITLE
fix (jkube-kit/enricher) : YAML multiline annotations incorrectly serialized on windows

### DIFF
--- a/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/visitor/MetadataVisitor.java
+++ b/jkube-kit/enricher/api/src/main/java/org/eclipse/jkube/kit/enricher/api/visitor/MetadataVisitor.java
@@ -20,6 +20,8 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.jkube.kit.config.resource.MetaDataConfig;
 import org.eclipse.jkube.kit.config.resource.ResourceConfig;
@@ -73,6 +75,7 @@ public class MetadataVisitor<T extends VisitableBuilder> extends TypedVisitor<T>
   private final Supplier<Properties> labelSupplier;
   private final Function<T, ObjectMetaFluent<?>> objectMeta;
   private final Function<ObjectMetaFluent<?>, Runnable> endMetadata;
+  private static final Pattern CONTAINS_LINE_BREAK = Pattern.compile("\r?\n");
 
   public MetadataVisitor(
       Class<T> clazz,
@@ -112,8 +115,12 @@ public class MetadataVisitor<T extends VisitableBuilder> extends TypedVisitor<T>
   }
 
   private String appendTrailingNewLineIfMultiline(String value) {
-    if (value.contains(System.lineSeparator()) && !value.endsWith(System.lineSeparator())) {
-      return value + System.lineSeparator();
+    Matcher m = CONTAINS_LINE_BREAK.matcher(value);
+    if (m.find()) {
+      String eol = m.group();
+      if (!value.endsWith(eol)) {
+        return value + eol;
+      }
     }
     return value;
   }


### PR DESCRIPTION
## Description

Related to #2841

Currently for enforcing trailing newline in case of multi line strings in resource annotations, we were relying on presence of `System.lineSeparator()`.

This was causing problems as YAML multiline scalar values are converted into strings with Line Feed (`\n`) endings when they're deserialized into objects. I checked in YAML spec and found this:

https://yaml.org/spec/1.2.2/#line-break-characters

> Line breaks inside[ scalar content](https://yaml.org/spec/1.2.2/#scalar) must be normalized by the YAML[ processor](https://yaml.org/spec/1.2.2/#processes-and-models). Each such line break must be[ parsed](https://yaml.org/spec/1.2.2/#parsing-the-presentation-stream) into a single line feed character. The original line break format is a[ presentation detail](https://yaml.org/spec/1.2.2/#presenting-the-serialization-tree) and must not be used to convey[ content](https://yaml.org/spec/1.2.2/#nodes) information.

> Outside[ scalar content](https://yaml.org/spec/1.2.2/#scalar), YAML allows any line break to be used to terminate lines.

Modify logic in MetadataVisitor with respect to this behavior.

With this change, [kubernetes-maven-plugin/it/metadata-labels-annotations](https://github.com/eclipse-jkube/jkube/blob/master/kubernetes-maven-plugin/it/src/it/metadata-labels-annotations/pom.xml#L83) integration test is passing on Windows


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
