### PR TITLE
refactor (jkube-kit) : Move logic for adding OpenShift Build specific properties to DefaultGeneratorManager

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.jkube.generator.api.DefaultGeneratorManager;
 import org.eclipse.jkube.generator.api.GeneratorContext;
 import org.eclipse.jkube.gradle.plugin.GradleLogger;
@@ -167,6 +168,7 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
         .prePackagePhase(false)
         .useProjectClasspath(kubernetesExtension.getUseProjectClassPathOrDefault())
         .sourceDirectory(kubernetesExtension.getBuildSourceDirectoryOrDefault())
+        .openshiftNamespace(StringUtils.isNotBlank(kubernetesExtension.getNamespaceOrNull()) ? kubernetesExtension.getNamespaceOrNull() : clusterAccess.getNamespace())
         .buildTimestamp(getBuildTimestamp(null, null, kubernetesExtension.javaProject.getBuildDirectory().getAbsolutePath(),
             DOCKER_BUILD_TIMESTAMP))
         .filter(kubernetesExtension.getFilterOrNull());

--- a/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTask.java
+++ b/gradle-plugin/openshift/src/main/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftResourceTask.java
@@ -13,17 +13,9 @@
  */
 package org.eclipse.jkube.gradle.plugin.task;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Properties;
-
 import javax.inject.Inject;
 
 import org.eclipse.jkube.gradle.plugin.OpenShiftExtension;
-import org.eclipse.jkube.kit.config.image.ImageConfiguration;
-import org.eclipse.jkube.kit.config.resource.RuntimeMode;
-
-import static org.eclipse.jkube.kit.build.api.helper.ImageNameFormatter.DOCKER_IMAGE_USER;
 
 public class OpenShiftResourceTask extends KubernetesResourceTask implements OpenShiftJKubeTask {
 
@@ -32,20 +24,5 @@ public class OpenShiftResourceTask extends KubernetesResourceTask implements Ope
     super(extensionClass);
     setDescription(
       "Generates or copies the OpenShift JSON file and attaches it to the build so its installed and released to maven repositories like other build artifacts.");
-  }
-
-  @Override
-  public List<ImageConfiguration> resolveImages() {
-    RuntimeMode runtimeMode = kubernetesExtension.getRuntimeMode();
-    final Properties properties = kubernetesExtension.javaProject.getProperties();
-    if (!properties.contains(DOCKER_IMAGE_USER)) {
-      String namespaceToBeUsed = Optional.ofNullable(kubernetesExtension.getNamespaceOrNull()).orElse(clusterAccess.getNamespace());
-      kitLogger.info("Using container image name of namespace: " + namespaceToBeUsed);
-      properties.setProperty(DOCKER_IMAGE_USER, namespaceToBeUsed);
-    }
-    if (!properties.contains(RuntimeMode.JKUBE_EFFECTIVE_PLATFORM_MODE)) {
-      properties.setProperty(RuntimeMode.JKUBE_EFFECTIVE_PLATFORM_MODE, runtimeMode.toString());
-    }
-    return super.resolveImages();
   }
 }

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/DefaultGeneratorManager.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/DefaultGeneratorManager.java
@@ -52,11 +52,11 @@ public class DefaultGeneratorManager implements GeneratorManager {
   public DefaultGeneratorManager(GeneratorContext context) {
     this.genCtx = context;
     propertyConfigResolver = new PropertyConfigResolver();
+    addOpenShiftBuildRelatedProperties();
   }
 
   @Override
   public List<ImageConfiguration> generateAndMerge(List<ImageConfiguration> unresolvedImages) {
-    addOpenShiftBuildRelatedProperties();
     final List<ImageConfiguration> resolvedImages = resolveImages(unresolvedImages);
     final List<ImageConfiguration> generatedImages = generateImages(resolvedImages);
     final List<ImageConfiguration> filteredImages = filterImages(generatedImages);
@@ -122,10 +122,11 @@ public class DefaultGeneratorManager implements GeneratorManager {
     return filteredImages;
   }
 
+  // TODO: Should be moved to a more suitable place (Probably within the JavaProject class)
   private void addOpenShiftBuildRelatedProperties() {
     if (genCtx.getRuntimeMode() == RuntimeMode.OPENSHIFT) {
       final Properties properties = genCtx.getProject().getProperties();
-      String namespaceToBeUsed = genCtx.getOpenshiftNamespace();
+      final String namespaceToBeUsed = genCtx.getOpenshiftNamespace();
       if (!properties.contains(DOCKER_IMAGE_USER) && StringUtils.isNotBlank(namespaceToBeUsed)) {
         genCtx.getLogger().info("Using container image name of namespace: " + namespaceToBeUsed);
         properties.setProperty(DOCKER_IMAGE_USER, namespaceToBeUsed);

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/GeneratorContext.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/GeneratorContext.java
@@ -57,6 +57,7 @@ public class GeneratorContext {
     private String openshiftPullSecret;
     private String openshiftPushSecret;
     private String openshiftBuildOutputKind;
+    private String openshiftNamespace;
     private BuildRecreateMode openshiftBuildRecreate;
 
 

--- a/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/DefaultGeneratorManagerTest.java
+++ b/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/DefaultGeneratorManagerTest.java
@@ -29,6 +29,7 @@ import org.eclipse.jkube.kit.config.image.GeneratorManager;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.ProcessorConfig;
+import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -275,6 +276,23 @@ class DefaultGeneratorManagerTest {
         .hasFieldOrPropertyWithValue("openshiftPushSecret", "push-secret-via-image-config")
         .hasFieldOrPropertyWithValue("openshiftBuildOutputKind", "ImageStreamTag-via-image-config")
         .hasFieldOrPropertyWithValue("openshiftBuildRecreateMode", BuildRecreateMode.buildConfig);
+    }
+
+    @Test
+    void whenOpenShiftRuntimeMode_thenShouldResolveGroupToNamespace() {
+      // Given
+      baseImageConfig = baseImageConfig.toBuilder().name("%g/%a").build();
+      generatorContext = generatorContext.toBuilder()
+        .openshiftNamespace("test-custom-namespace")
+        .runtimeMode(RuntimeMode.OPENSHIFT)
+        .build();
+      // When
+      final List<ImageConfiguration> result = new DefaultGeneratorManager(generatorContext)
+        .generateAndMerge(Collections.singletonList(baseImageConfig));
+      // Then
+      assertThat(result)
+        .singleElement()
+        .hasFieldOrPropertyWithValue("name", "test-custom-namespace/test-java-project");
     }
   }
 


### PR DESCRIPTION
## Description

In Resource mojo and tasks, we've duplicated code that adds the following properties to JavaProject in case of OpenShift mode:
- `jkube.image.user` : Sets image user property to currently logged in OpenShift namespace so that image user portion points to namespace
- `jkube.internal.effective.platform.mode` : Used by some enrichers to determine whether current platform is OpenShift. This looks like a remnant of Fabric8 Maven Plugin refactor. We should get rid of this in follow up PR.

This PR only moves code from Mojos/Tasks -> DefaultGeneratorManager.generateAndMerge()



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [X] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
