### PR TITLE
KubernetesWatchTask.getWatchContext and KubernetesWatchTask.createWat…

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/AbstractJKubeTask.java
@@ -139,7 +139,8 @@ public abstract class AbstractJKubeTask extends DefaultTask implements Kubernete
                 .authConfig(kubernetesExtension.authConfig != null ? kubernetesExtension.authConfig.toMap() : null)
                 .skipExtendedAuth(kubernetesExtension.getSkipExtendedAuth().getOrElse(false))
                 .passwordDecryptionMethod(s -> s)
-                .registry(kubernetesExtension.getPushRegistryOrNull())
+                .registry(kubernetesExtension.getPushRegistryOrNull() != null ?
+                  kubernetesExtension.getPushRegistryOrNull() : kubernetesExtension.getRegistryOrDefault())
                 .build())
             .build())
         .clusterAccess(clusterAccess)

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTask.java
@@ -15,13 +15,11 @@ package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
 import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
-import org.eclipse.jkube.kit.common.RegistryConfig;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
 import org.eclipse.jkube.kit.config.service.JKubeServiceException;
 import org.eclipse.jkube.kit.config.service.JKubeServiceHub;
 
 import javax.inject.Inject;
-import java.util.Collections;
 
 public class KubernetesPushTask extends AbstractJKubeTask {
   @Inject
@@ -41,7 +39,7 @@ public class KubernetesPushTask extends AbstractJKubeTask {
   public void run() {
     try {
       jKubeServiceHub.getBuildService()
-          .push(resolvedImages, kubernetesExtension.getPushRetriesOrDefault(), initRegistryConfig(), kubernetesExtension.getSkipTagOrDefault());
+          .push(resolvedImages, kubernetesExtension.getPushRetriesOrDefault(), kubernetesExtension.getSkipTagOrDefault());
     } catch (JKubeServiceException e) {
       throw new IllegalStateException("Error in pushing image: " + e.getMessage(), e);
     }
@@ -50,16 +48,6 @@ public class KubernetesPushTask extends AbstractJKubeTask {
   @Override
   protected boolean shouldSkip() {
     return super.shouldSkip() || kubernetesExtension.getSkipPushOrDefault();
-  }
-
-  private RegistryConfig initRegistryConfig() {
-    final String specificRegistry = kubernetesExtension.getPushRegistryOrNull();
-    return RegistryConfig.builder()
-      .settings(Collections.emptyList())
-      .authConfig(kubernetesExtension.authConfig != null ? kubernetesExtension.authConfig.toMap() : null)
-      .skipExtendedAuth(kubernetesExtension.getSkipExtendedAuthOrDefault())
-      .registry(specificRegistry != null ? specificRegistry : kubernetesExtension.getRegistryOrDefault())
-      .passwordDecryptionMethod(password -> password).build();
   }
 
   protected BuildServiceConfig.BuildServiceConfigBuilder buildServiceConfigBuilder() {

--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
@@ -72,7 +72,7 @@ public class KubernetesWatchTask extends AbstractJKubeTask {
     }
   }
 
-  private WatcherContext createWatcherContext() throws IOException {
+  private WatcherContext createWatcherContext() {
     WatchContext watchContext = jKubeServiceHub.getDockerServiceHub() != null ? getWatchContext() : null;
     return WatcherContext.builder()
         .buildContext(jKubeServiceHub.getConfiguration())
@@ -87,7 +87,7 @@ public class KubernetesWatchTask extends AbstractJKubeTask {
         .build();
   }
 
-  private WatchContext getWatchContext() throws IOException {
+  private WatchContext getWatchContext() {
     final DockerServiceHub hub = jKubeServiceHub.getDockerServiceHub();
     return WatchContext.builder()
         .watchInterval(kubernetesExtension.getWatchIntervalOrDefault())

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesPushTaskTest.java
@@ -87,7 +87,7 @@ class KubernetesPushTaskTest {
     // Then
     assertThat(dockerBuildServiceMockedConstruction.constructed()).hasSize(1);
     verify(dockerBuildServiceMockedConstruction.constructed().iterator().next(), times(1))
-        .push(argThat(images -> images.iterator().next().getName().equals("foo/bar:latest")), eq(0), any(), eq(false));
+        .push(argThat(images -> images.iterator().next().getName().equals("foo/bar:latest")), eq(0), eq(false));
   }
 
 
@@ -109,7 +109,7 @@ class KubernetesPushTaskTest {
 
     // Then
     assertThat(dockerBuildServiceMockedConstruction.constructed()).isEmpty();
-    verify(pushTask.jKubeServiceHub.getBuildService(), times(0)).push(any(), anyInt(), any(), anyBoolean());
+    verify(pushTask.jKubeServiceHub.getBuildService(), times(0)).push(any(), anyInt(), anyBoolean());
     verify(taskEnvironment.logger, times(1)).lifecycle(contains("k8s: `k8sPush` task is skipped."));
 
   }

--- a/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftPushTaskTest.java
+++ b/gradle-plugin/openshift/src/test/java/org/eclipse/jkube/gradle/plugin/task/OpenShiftPushTaskTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.MockedConstruction;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mockConstruction;
@@ -72,7 +71,7 @@ class OpenShiftPushTaskTest {
       // Then
       assertThat(openshiftBuildServiceMockedConstruction.constructed()).hasSize(1);
       verify(openshiftBuildServiceMockedConstruction.constructed().iterator().next())
-          .push(argThat(images -> images.iterator().next().getName().equals("foo/bar:latest")), eq(0), any(), eq(false));
+          .push(argThat(images -> images.iterator().next().getName().equals("foo/bar:latest")), eq(0), eq(false));
   }
 
   @Test

--- a/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/RegistryService.java
+++ b/jkube-kit/build/service/docker/src/main/java/org/eclipse/jkube/kit/build/service/docker/RegistryService.java
@@ -31,7 +31,7 @@ import static org.eclipse.jkube.kit.build.api.helper.RegistryUtil.getApplicableP
 import static org.eclipse.jkube.kit.build.api.helper.RegistryUtil.getApplicablePushRegistryFrom;
 
 /**
- * Allows to interact with registries, eg. to push/pull images.
+ * Allows to interact with registries, e.g. to push/pull images.
  */
 public class RegistryService {
 
@@ -54,8 +54,9 @@ public class RegistryService {
      * @param skipTag flag to skip pushing tagged images
      * @throws IOException exception
      */
-    public void pushImage(ImageConfiguration imageConfig,
-                          int retries, RegistryConfig registryConfig, boolean skipTag) throws IOException {
+    public void pushImage(
+      ImageConfiguration imageConfig, int retries, RegistryConfig registryConfig, boolean skipTag
+    ) throws IOException {
         BuildConfiguration buildConfig = imageConfig.getBuildConfiguration();
         String name = imageConfig.getName();
         if (buildConfig != null) {

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/ExternalCommandTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/ExternalCommandTest.java
@@ -56,7 +56,7 @@ class ExternalCommandTest {
     // When + Then
     assertThatIOException()
         .isThrownBy(testCommand::execute)
-        .withMessage("Process 'ls idontexist' exited with status 2");
+        .withMessageMatching("Process 'ls idontexist' exited with status [^0]");
   }
 
   @Test

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/AbstractImageBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/AbstractImageBuildService.java
@@ -13,7 +13,6 @@
  */
 package org.eclipse.jkube.kit.config.service;
 
-import org.eclipse.jkube.kit.common.RegistryConfig;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 
 import java.util.Collection;
@@ -27,7 +26,7 @@ public abstract class AbstractImageBuildService implements BuildService {
 
   protected abstract void buildSingleImage(ImageConfiguration imageConfiguration) throws JKubeServiceException;
 
-  protected abstract void pushSingleImage(ImageConfiguration imageConfiguration, int retries, RegistryConfig registryConfig, boolean skipTag) throws JKubeServiceException;
+  protected abstract void pushSingleImage(ImageConfiguration imageConfiguration, int retries, boolean skipTag) throws JKubeServiceException;
 
   /** {@inheritDoc} */
   @Override
@@ -37,8 +36,8 @@ public abstract class AbstractImageBuildService implements BuildService {
   }
 
   @Override
-  public final void push(Collection<ImageConfiguration> imageConfigs, int retries, RegistryConfig registryConfig, boolean skipTag) throws JKubeServiceException {
-    processImage(imageConfiguration -> pushSingleImage(imageConfiguration, retries, registryConfig, skipTag), "Skipped push", imageConfigs.toArray(new ImageConfiguration[0]));
+  public final void push(Collection<ImageConfiguration> imageConfigs, int retries, boolean skipTag) throws JKubeServiceException {
+    processImage(imageConfiguration -> pushSingleImage(imageConfiguration, retries, skipTag), "Skipped push", imageConfigs.toArray(new ImageConfiguration[0]));
   }
 
   @FunctionalInterface

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/BuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/BuildService.java
@@ -43,11 +43,10 @@ public interface BuildService {
      *
      * @param imageConfigs image configurations to process
      * @param retries number of retries
-     * @param registryConfig registry configuration
      * @param skipTag boolean value whether skip tagging or not
      * @throws JKubeServiceException in case of any error while building image
      */
-    void push(Collection<ImageConfiguration> imageConfigs, int retries, RegistryConfig registryConfig, boolean skipTag) throws JKubeServiceException;
+    void push(Collection<ImageConfiguration> imageConfigs, int retries, boolean skipTag) throws JKubeServiceException;
 
     /**
      * Post processing step called after all images has been build

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildService.java
@@ -19,7 +19,6 @@ import java.util.Objects;
 import org.eclipse.jkube.kit.build.service.docker.DockerServiceHub;
 import org.eclipse.jkube.kit.common.JKubeConfiguration;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
-import org.eclipse.jkube.kit.common.RegistryConfig;
 import org.eclipse.jkube.kit.config.resource.RuntimeMode;
 import org.eclipse.jkube.kit.config.service.AbstractImageBuildService;
 import org.eclipse.jkube.kit.config.service.BuildServiceConfig;
@@ -66,9 +65,10 @@ public class DockerBuildService extends AbstractImageBuildService {
     }
 
     @Override
-    protected void pushSingleImage(ImageConfiguration imageConfiguration, int retries, RegistryConfig registryConfig, boolean skipTag) throws JKubeServiceException {
+    protected void pushSingleImage(ImageConfiguration imageConfiguration, int retries, boolean skipTag) throws JKubeServiceException {
         try {
-            dockerServices.getRegistryService().pushImage(imageConfiguration, retries, registryConfig, skipTag);
+            dockerServices.getRegistryService()
+              .pushImage(imageConfiguration, retries, jKubeConfiguration.getPushRegistryConfig(), skipTag);
         } catch (IOException ex) {
             throw new JKubeServiceException("Error while trying to push the image: " + ex.getMessage(), ex);
         }

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/JibImageBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/kubernetes/JibImageBuildService.java
@@ -116,8 +116,9 @@ public class JibImageBuildService extends AbstractImageBuildService {
     }
 
     @Override
-    protected void pushSingleImage(ImageConfiguration imageConfiguration, int retries, RegistryConfig registryConfig, boolean skipTag) throws JKubeServiceException {
+    protected void pushSingleImage(ImageConfiguration imageConfiguration, int retries, boolean skipTag) throws JKubeServiceException {
         try {
+            final RegistryConfig registryConfig = configuration.getPushRegistryConfig();
             final ImageConfiguration imageConfigToPush = prependPushRegistry(imageConfiguration, registryConfig);
             kitLogger.info("This push refers to: %s", imageConfigToPush.getName());
             kitLogger.info("Pushing image: %s", new ImageName(imageConfigToPush.getName()).getFullName());

--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenshiftBuildService.java
@@ -173,7 +173,7 @@ public class OpenshiftBuildService extends AbstractImageBuildService {
     }
 
     @Override
-    protected void pushSingleImage(ImageConfiguration imageConfiguration, int retries, RegistryConfig registryConfig, boolean skipTag) {
+    protected void pushSingleImage(ImageConfiguration imageConfiguration, int retries, boolean skipTag) {
         // Do nothing. Image is pushed as part of build phase
         log.warn("Image is pushed to OpenShift's internal registry during oc:build goal. Skipping...");
     }

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/kubernetes/DockerBuildServiceTest.java
@@ -122,7 +122,7 @@ class DockerBuildServiceTest {
   @Test
   void push_withDefaults_shouldPush() throws Exception {
     // When
-    new DockerBuildService(mockedJKubeServiceHub).push(Collections.emptyList(), 0, null, false);
+    new DockerBuildService(mockedJKubeServiceHub).push(Collections.emptyList(), 0, false);
     // Then
     verify(mockedJKubeServiceHub.getDockerServiceHub().getRegistryService(), times(0))
         .pushImage(any(), eq(0), isNull(), eq(false));

--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceTest.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceTest.java
@@ -91,7 +91,7 @@ class OpenShiftBuildServiceTest {
     when(jKubeServiceHub.getLog()).thenReturn(kitLogger);
 
     // When
-    new OpenshiftBuildService(jKubeServiceHub).push(Collections.emptyList(), 0, new RegistryConfig(), false);
+    new OpenshiftBuildService(jKubeServiceHub).push(Collections.emptyList(), 0, false);
     // Then
     verify(kitLogger, times(0)).warn("Image is pushed to OpenShift's internal registry during oc:build goal. Skipping...");
   }
@@ -102,7 +102,7 @@ class OpenShiftBuildServiceTest {
     when(jKubeServiceHub.getLog()).thenReturn(kitLogger);
 
     // When
-    new OpenshiftBuildService(jKubeServiceHub).push(Collections.singletonList(imageConfiguration), 0, new RegistryConfig(), false);
+    new OpenshiftBuildService(jKubeServiceHub).push(Collections.singletonList(imageConfiguration), 0, false);
     // Then
     verify(kitLogger, times(1)).warn("Image is pushed to OpenShift's internal registry during oc:build goal. Skipping...");
   }

--- a/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/generator/SpringBootGeneratorIntegrationTest.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/test/java/org/eclipse/jkube/springboot/generator/SpringBootGeneratorIntegrationTest.java
@@ -159,7 +159,8 @@ class SpringBootGeneratorIntegrationTest {
       // Then
       assertThat(images)
         .singleElement()
-        .extracting("buildConfiguration.ports").asList()
+        .extracting("buildConfiguration.ports")
+        .asInstanceOf(InstanceOfAssertFactories.list(String.class))
         .contains("8080");
     }
     @Test
@@ -170,7 +171,8 @@ class SpringBootGeneratorIntegrationTest {
         .customize(new ArrayList<>(), false);
       // Then
       assertThat(images).singleElement()
-        .extracting("buildConfiguration.ports").asList()
+        .extracting("buildConfiguration.ports")
+        .asInstanceOf(InstanceOfAssertFactories.list(String.class))
         .contains("8778");
     }
 
@@ -182,7 +184,8 @@ class SpringBootGeneratorIntegrationTest {
         .customize(new ArrayList<>(), false);
       // Then
       assertThat(images).singleElement()
-        .extracting("buildConfiguration.ports").asList()
+        .extracting("buildConfiguration.ports")
+        .asInstanceOf(InstanceOfAssertFactories.list(String.class))
         .contains("9779");
     }
 
@@ -216,12 +219,15 @@ class SpringBootGeneratorIntegrationTest {
         .hasFieldOrPropertyWithValue("targetDir", "/deployments")
         .hasFieldOrPropertyWithValue("excludeFinalOutputArtifact", true)
         .extracting(AssemblyConfiguration::getLayers)
-        .asList().hasSize(1)
+        .asInstanceOf(InstanceOfAssertFactories.list(Assembly.class))
+        .hasSize(1)
         .satisfies(layers -> assertThat(layers).element(0).asInstanceOf(InstanceOfAssertFactories.type(Assembly.class))
           .extracting(Assembly::getFileSets)
-          .asList().element(2)
+          .asInstanceOf(InstanceOfAssertFactories.list(AssemblyFileSet.class))
+          .element(2)
           .hasFieldOrPropertyWithValue("outputDirectory", new File("."))
-          .extracting("includes").asList()
+          .extracting("includes")
+          .asInstanceOf(InstanceOfAssertFactories.list(String.class))
           .containsExactly("fat.jar"));
     }
 
@@ -258,7 +264,8 @@ class SpringBootGeneratorIntegrationTest {
       // Then
       assertThat(images)
         .singleElement()
-        .extracting("buildConfiguration.ports").asList()
+        .extracting("buildConfiguration.ports")
+        .asInstanceOf(InstanceOfAssertFactories.list(String.class))
         .contains("8081");
     }
 
@@ -340,7 +347,7 @@ class SpringBootGeneratorIntegrationTest {
         .hasFieldOrPropertyWithValue("targetDir", "/deployments")
         .hasFieldOrPropertyWithValue("excludeFinalOutputArtifact", true)
         .extracting(AssemblyConfiguration::getLayers)
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(Assembly.class))
         .hasSize(5)
         .contains(
           Assembly.builder()
@@ -440,13 +447,16 @@ class SpringBootGeneratorIntegrationTest {
           .hasFieldOrPropertyWithValue("targetDir", "/")
           .hasFieldOrPropertyWithValue("excludeFinalOutputArtifact", true)
           .extracting(AssemblyConfiguration::getLayers)
-          .asList().hasSize(1)
+          .asInstanceOf(InstanceOfAssertFactories.list(Assembly.class))
+          .hasSize(1)
           .satisfies(layers -> assertThat(layers).element(0).asInstanceOf(InstanceOfAssertFactories.type(Assembly.class))
               .extracting(Assembly::getFileSets)
-              .asList().element(2)
+              .asInstanceOf(InstanceOfAssertFactories.list(AssemblyFileSet.class))
+              .element(2)
               .hasFieldOrPropertyWithValue("outputDirectory", new File("."))
               .hasFieldOrPropertyWithValue("fileMode", "0755")
-              .extracting("includes").asList()
+              .extracting("includes")
+              .asInstanceOf(InstanceOfAssertFactories.list(String.class))
               .containsExactly("native-binary-artifact"));
     }
 

--- a/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/PushMojo.java
+++ b/kubernetes-maven-plugin/plugin/src/main/java/org/eclipse/jkube/maven/plugin/mojo/build/PushMojo.java
@@ -23,7 +23,6 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * Uploads the built Docker images to a Docker registry
  *
  * @author roland
- * @since 16/03/16
  */
 @Mojo(name = "push", defaultPhase = LifecyclePhase.INSTALL, requiresDependencyResolution = ResolutionScope.COMPILE)
 public class PushMojo extends AbstractDockerMojo {
@@ -52,7 +51,7 @@ public class PushMojo extends AbstractDockerMojo {
         }
 
         try {
-            jkubeServiceHub.getBuildService().push(getResolvedImages(), retries, getRegistryConfig(pushRegistry), skipTag);
+            jkubeServiceHub.getBuildService().push(getResolvedImages(), retries, skipTag);
         } catch (Exception ex) {
             throw new MojoExecutionException(ex.getMessage(), ex);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <version.json-smart>2.5.1</version.json-smart> <!-- Transitive dependency  required by citrus -->
     <version.junit5>5.10.2</version.junit5>
     <version.kubernetes-client>6.12.1</version.kubernetes-client>
-    <version.license-maven-plugin>4.4</version.license-maven-plugin>
+    <version.license-maven-plugin>4.5</version.license-maven-plugin>
     <version.lombok>1.18.32</version.lombok>
     <version.lombok-maven-plugin>1.18.20.0</version.lombok-maven-plugin>
     <version.maven-compiler-plugin>3.13.0</version.maven-compiler-plugin>


### PR DESCRIPTION
KubernetesWatchTask.getWatchContext The declared Exception is never thrown

## Description
Fixes #3054 


## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

