### PR TITLE
KubernetesWatchTask.getWatchContext The declared exception is never thrown

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesWatchTask.java
@@ -29,7 +29,6 @@ import org.eclipse.jkube.watcher.api.WatcherContext;
 import org.eclipse.jkube.watcher.api.WatcherManager;
 
 import javax.inject.Inject;
-import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 
@@ -72,7 +71,7 @@ public class KubernetesWatchTask extends AbstractJKubeTask {
     }
   }
 
-  private WatcherContext createWatcherContext() throws IOException {
+  private WatcherContext createWatcherContext() {
     WatchContext watchContext = jKubeServiceHub.getDockerServiceHub() != null ? getWatchContext() : null;
     return WatcherContext.builder()
         .buildContext(jKubeServiceHub.getConfiguration())
@@ -87,7 +86,7 @@ public class KubernetesWatchTask extends AbstractJKubeTask {
         .build();
   }
 
-  private WatchContext getWatchContext() throws IOException {
+  private WatchContext getWatchContext() {
     final DockerServiceHub hub = jKubeServiceHub.getDockerServiceHub();
     return WatchContext.builder()
         .watchInterval(kubernetesExtension.getWatchIntervalOrDefault())


### PR DESCRIPTION
## Description
KubernetesWatchTask.getWatchContext The declared exception is never thrown

Fixes #3054 


## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
