### PR TITLE
doc : Add note in SpringBootHealthCheckEnricher documentation about enabled management health probe endpoints

### DIFF
--- a/jkube-kit/doc/src/main/asciidoc/inc/enricher/spring-boot-healthcheck/_jkube_healthcheck_spring_boot.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/enricher/spring-boot-healthcheck/_jkube_healthcheck_spring_boot.adoc
@@ -14,6 +14,14 @@ endif::[]
 
 The enricher will try to discover the settings from the `application.properties` / `application.yaml` Spring Boot configuration file.
 
+`/actuator/health` is the default endpoint for the liveness and readiness probes.
+
+If the user has enabled the `management.health.probes.enabled` property this Enricher uses the `/actuator/health/liveness` as liveness and `/actuator/health/readiness` as readiness probe endpoints instead.
+[source,properties]
+----
+management.health.probes.enabled=true
+----
+
 The port number is read from the `management.port` option, and will use the default value of `8080`
 The scheme will use HTTPS if `server.ssl.key-store` option is in use, and fallback to use `HTTP` otherwise.
 


### PR DESCRIPTION
## Description

Documentation for #2663

Add a note in SpringBootHealthCheckEnricher documentation about the effect of `management.health.probes.enabled` property on enricher behavior.




## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [X] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [X] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
