### PR TITLE
fix: don't unconditionally add latest tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Usage:
 ./scripts/extract-changelog-for-version.sh 1.3.37 5
 ```
 ### 1.17-SNAPSHOT
+* Fix #3161: JavaExecGenerator should honor %t setting and not unconditionally add `latest` tag
 * Fix #2098: Add support for multi-platform container image builds in jib build strategy
 * Fix #2335: Add support for configuring nodeSelector spec for controller via xml/groovy DSL configuration
 * Fix #2459: Allow configuring Buildpacks build via ImageConfiguration

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
@@ -234,12 +234,6 @@ public abstract class BaseGenerator implements Generator {
         return true;
     }
 
-    protected void addLatestTagIfSnapshot(BuildConfiguration.BuildConfigurationBuilder buildBuilder) {
-        if (getProject().getVersion().endsWith("-SNAPSHOT") && !getImageName().contains("%t")) {
-            buildBuilder.tags(Collections.singletonList("latest"));
-        }
-    }
-
     protected void addTagsFromConfig(BuildConfiguration.BuildConfigurationBuilder buildConfigurationBuilder) {
         String commaSeparatedTags = getConfigWithFallback(Config.TAGS, "jkube.generator.tags", null);
         if (StringUtils.isNotBlank(commaSeparatedTags)) {

--- a/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
+++ b/jkube-kit/generator/api/src/main/java/org/eclipse/jkube/generator/api/support/BaseGenerator.java
@@ -235,7 +235,7 @@ public abstract class BaseGenerator implements Generator {
     }
 
     protected void addLatestTagIfSnapshot(BuildConfiguration.BuildConfigurationBuilder buildBuilder) {
-        if (getProject().getVersion().endsWith("-SNAPSHOT")) {
+        if (getProject().getVersion().endsWith("-SNAPSHOT") && !getImageName().contains("%t")) {
             buildBuilder.tags(Collections.singletonList("latest"));
         }
     }

--- a/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/support/BaseGeneratorTest.java
+++ b/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/support/BaseGeneratorTest.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.entry;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.eclipse.jkube.generator.api.support.BaseGenerator.PROPERTY_JKUBE_GENERATOR_NAME;
 
 class BaseGeneratorTest {
 
@@ -366,6 +367,25 @@ class BaseGeneratorTest {
         .singleElement()
         .asString()
         .endsWith("latest");
+  }
+
+  @Test
+  @DisplayName("omit latest tag if formatter contains '%t'")
+  void omitLatestTagIfTimestamped() {
+    properties.put(PROPERTY_JKUBE_GENERATOR_NAME, "%g/%a:%t");
+    ctx = ctx.toBuilder().project(
+            ctx.getProject().toBuilder()
+                    .version("1.2-SNAPSHOT")
+                    .properties(properties)
+                    .build())
+            .build();
+    BuildConfiguration.BuildConfigurationBuilder builder = BuildConfiguration.builder();
+
+    new TestBaseGenerator(ctx, "test-generator").addLatestTagIfSnapshot(builder);
+
+    BuildConfiguration buildConfiguration = builder.build();
+    List<String> tags = buildConfiguration.getTags();
+    assertThat(tags).isEmpty();
   }
 
   @Test

--- a/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/support/BaseGeneratorTest.java
+++ b/jkube-kit/generator/api/src/test/java/org/eclipse/jkube/generator/api/support/BaseGeneratorTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.entry;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
-import static org.eclipse.jkube.generator.api.support.BaseGenerator.PROPERTY_JKUBE_GENERATOR_NAME;
 
 class BaseGeneratorTest {
 
@@ -353,39 +352,6 @@ class BaseGeneratorTest {
 
     // Then
     assertThat(result).isTrue();
-  }
-
-  @Test
-  @DisplayName("add latest tag if project's version is SNAPSHOT")
-  void addLatestTagIfSnapshot() {
-    ctx = ctx.toBuilder().project(ctx.getProject().toBuilder().version("1.2-SNAPSHOT").build()).build();
-    BuildConfiguration.BuildConfigurationBuilder builder = BuildConfiguration.builder();
-    new TestBaseGenerator(ctx, "test-generator").addLatestTagIfSnapshot(builder);
-    BuildConfiguration config = builder.build();
-    List<String> tags = config.getTags();
-    assertThat(tags)
-        .singleElement()
-        .asString()
-        .endsWith("latest");
-  }
-
-  @Test
-  @DisplayName("omit latest tag if formatter contains '%t'")
-  void omitLatestTagIfTimestamped() {
-    properties.put(PROPERTY_JKUBE_GENERATOR_NAME, "%g/%a:%t");
-    ctx = ctx.toBuilder().project(
-            ctx.getProject().toBuilder()
-                    .version("1.2-SNAPSHOT")
-                    .properties(properties)
-                    .build())
-            .build();
-    BuildConfiguration.BuildConfigurationBuilder builder = BuildConfiguration.builder();
-
-    new TestBaseGenerator(ctx, "test-generator").addLatestTagIfSnapshot(builder);
-
-    BuildConfiguration buildConfiguration = builder.build();
-    List<String> tags = buildConfiguration.getTags();
-    assertThat(tags).isEmpty();
   }
 
   @Test

--- a/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
+++ b/jkube-kit/generator/java-exec/src/main/java/org/eclipse/jkube/generator/javaexec/JavaExecGenerator.java
@@ -155,7 +155,6 @@ public class JavaExecGenerator extends BaseGenerator {
       addJolokiaPort(buildBuilder);
       addPrometheusPort(buildBuilder);
 
-      addLatestTagIfSnapshot(buildBuilder);
       addTagsFromConfig(buildBuilder);
       buildBuilder.workdir(getBuildWorkdir());
       buildBuilder.entryPoint(getBuildEntryPoint());

--- a/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/JavaExecGeneratorCustomPropertiesTest.java
+++ b/jkube-kit/generator/java-exec/src/test/java/org/eclipse/jkube/generator/javaexec/JavaExecGeneratorCustomPropertiesTest.java
@@ -60,7 +60,7 @@ class JavaExecGeneratorCustomPropertiesTest {
         .hasFieldOrPropertyWithValue("alias", "java-exec")
         .extracting(ImageConfiguration::getBuildConfiguration)
         .hasFieldOrPropertyWithValue("from", "custom-image")
-        .hasFieldOrPropertyWithValue("tags", Collections.singletonList("latest"))
+        .hasFieldOrPropertyWithValue("tags", Collections.emptyList())
         .hasFieldOrPropertyWithValue("env", new HashMap<String, String>(){{
           put("JAVA_APP_DIR", "/other-dir");
           put("JAVA_MAIN_CLASS", "com.example.Main");

--- a/jkube-kit/generator/karaf/src/main/java/org/eclipse/jkube/generator/karaf/KarafGenerator.java
+++ b/jkube-kit/generator/karaf/src/main/java/org/eclipse/jkube/generator/karaf/KarafGenerator.java
@@ -76,7 +76,6 @@ public class KarafGenerator extends BaseGenerator {
     if (!prePackagePhase) {
       buildBuilder.assembly(createDefaultAssembly());
     }
-    addLatestTagIfSnapshot(buildBuilder);
     addTagsFromConfig(buildBuilder);
     imageBuilder
         .name(getImageName())

--- a/jkube-kit/generator/karaf/src/test/java/org/eclipse/jkube/generator/karaf/KarafGeneratorTest.java
+++ b/jkube-kit/generator/karaf/src/test/java/org/eclipse/jkube/generator/karaf/KarafGeneratorTest.java
@@ -93,7 +93,7 @@ class KarafGeneratorTest {
         .hasFieldOrPropertyWithValue("name", "%g/%a:%l")
         .hasFieldOrPropertyWithValue("alias", "karaf")
         .extracting(ImageConfiguration::getBuildConfiguration)
-        .hasFieldOrPropertyWithValue("tags", Collections.singletonList("latest"))
+        .hasFieldOrPropertyWithValue("tags", Collections.emptyList())
         .hasFieldOrPropertyWithValue("ports", Arrays.asList("8181", "8778"))
         .extracting(BuildConfiguration::getEnv)
         .asInstanceOf(InstanceOfAssertFactories.MAP)

--- a/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
+++ b/jkube-kit/generator/webapp/src/main/java/org/eclipse/jkube/generator/webapp/WebAppGenerator.java
@@ -129,7 +129,6 @@ public class WebAppGenerator extends BaseGenerator {
     if (!prePackagePhase) {
       buildBuilder.assembly(createAssembly(handler));
     }
-    addLatestTagIfSnapshot(buildBuilder);
     addTagsFromConfig(buildBuilder);
     imageBuilder
         .name(getImageName())

--- a/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/WebAppGeneratorTest.java
+++ b/jkube-kit/generator/webapp/src/test/java/org/eclipse/jkube/generator/webapp/WebAppGeneratorTest.java
@@ -118,7 +118,7 @@ class WebAppGeneratorTest {
           .hasFieldOrPropertyWithValue("name", "%g/%a:%l")
           .hasFieldOrPropertyWithValue("alias", "webapp")
           .extracting(ImageConfiguration::getBuildConfiguration)
-          .hasFieldOrPropertyWithValue("tags", Collections.singletonList("latest"))
+          .hasFieldOrPropertyWithValue("tags", Collections.emptyList())
           .hasFieldOrPropertyWithValue("ports", Collections.singletonList("8080"))
           .hasFieldOrPropertyWithValue("env", new HashMap<String, String>() {{
               put("DEPLOY_DIR", "/deployments");
@@ -164,7 +164,7 @@ class WebAppGeneratorTest {
           .hasFieldOrPropertyWithValue("name", "%a:%l")
           .hasFieldOrPropertyWithValue("alias", "webapp")
           .extracting(ImageConfiguration::getBuildConfiguration)
-          .hasFieldOrPropertyWithValue("tags", Collections.singletonList("latest"))
+          .hasFieldOrPropertyWithValue("tags", Collections.emptyList())
           .hasFieldOrPropertyWithValue("ports", Arrays.asList("8082", "80"))
           .hasFieldOrPropertyWithValue("env", Collections.singletonMap("DEPLOY_DIR", "/other-dir"))
           .hasFieldOrPropertyWithValue("cmd.shell", "sleep 3600")


### PR DESCRIPTION

## Description

Tag `latest` should not be added when image name contains pattern `%t`, or it will likely break immutable repositories that don't allow overwriting artifact tags.

Fixes https://github.com/eclipse-jkube/jkube/issues/3161


## Type of change
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [X] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [X] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
