### PR TITLE
Duplicated getNewestPod method is removed from PortForwardService and KubernetesHelper.getNewestPod is used.

### DIFF
--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/PortForwardService.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/PortForwardService.java
@@ -140,7 +140,7 @@ public class PortForwardService {
                     } else {
                         candidatePods = Collections.singletonList(pod);
                     }
-                    Pod newPod = getNewestPod(candidatePods); // may be null
+                    Pod newPod = KubernetesHelper.getNewestPod(candidatePods); // may be null
                     if (!podEquals(nextForwardedPod[0], newPod)) {
                         nextForwardedPod[0] = newPod;
                         podChanged.signal();
@@ -200,23 +200,9 @@ public class PortForwardService {
         PodList list = pods.list();
         if (list != null) {
             List<Pod> items = list.getItems();
-            return getNewestPod(items);
+            return KubernetesHelper.getNewestPod(items);
         }
         return null;
-    }
-
-    private Pod getNewestPod(List<Pod> items) {
-        Pod targetPod = null;
-        if (items != null) {
-            for (Pod pod : items) {
-                if (KubernetesHelper.isPodWaiting(pod) || KubernetesHelper.isPodRunning(pod)) {
-                    if (targetPod == null || (KubernetesHelper.isPodReady(pod) && KubernetesHelper.isNewerResource(pod, targetPod))) {
-                        targetPod = pod;
-                    }
-                }
-            }
-        }
-        return targetPod;
     }
 
     // Visible for test


### PR DESCRIPTION

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #3136


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
