### PR TITLE
Replace AssertJ's deprecated asList() DSL method

### DIFF
--- a/jkube-kit/config/resource/src/test/java/org/eclipse/jkube/kit/config/resource/IngressConfigTest.java
+++ b/jkube-kit/config/resource/src/test/java/org/eclipse/jkube/kit/config/resource/IngressConfigTest.java
@@ -15,6 +15,7 @@ package org.eclipse.jkube.kit.config.resource;
 
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
@@ -36,27 +37,29 @@ class IngressConfigTest {
         IngressConfig.class);
     // Then
     assertThat(result)
-        .satisfies(ic -> assertThat(ic).extracting(IngressConfig::getIngressRules).asList().containsExactly(
-            IngressRuleConfig.builder()
-                .host("example.com")
-                .path(IngressRulePathConfig.builder()
-                    .pathType("ImplementationSpecific")
-                    .path("/path")
-                    .serviceName("service-name")
-                    .servicePort(8080)
-                    .resource(IngressRulePathResourceConfig.builder()
-                        .apiGroup("group.k8s.io")
-                        .kind("ResourceKind")
-                        .name("resource-name")
+        .satisfies(ic -> assertThat(ic).extracting(IngressConfig::getIngressRules)
+            .asInstanceOf(InstanceOfAssertFactories.list(IngressRuleConfig.class))
+            .containsExactly(
+                IngressRuleConfig.builder()
+                    .host("example.com")
+                    .path(IngressRulePathConfig.builder()
+                        .pathType("ImplementationSpecific")
+                        .path("/path")
+                        .serviceName("service-name")
+                        .servicePort(8080)
+                        .resource(IngressRulePathResourceConfig.builder()
+                            .apiGroup("group.k8s.io")
+                            .kind("ResourceKind")
+                            .name("resource-name")
+                            .build())
                         .build())
-                    .build())
-                .build()
-        ))
-        .satisfies(ic -> assertThat(ic).extracting(IngressConfig::getIngressTlsConfigs).asList()
-            .hasSize(1)
-            .element(0)
+                    .build()))
+        .satisfies(ic -> assertThat(ic).extracting(IngressConfig::getIngressTlsConfigs)
+            .asInstanceOf(InstanceOfAssertFactories.list(IngressTlsConfig.class))
+            .singleElement()
             .hasFieldOrPropertyWithValue("secretName", "shhhh")
-            .extracting("hosts").asList().containsExactly("tls.example.com")
-        );
+            .extracting("hosts")
+            .asInstanceOf(InstanceOfAssertFactories.list(String.class))
+            .containsExactly("tls.example.com"));
   }
 }

--- a/jkube-kit/config/resource/src/test/java/org/eclipse/jkube/kit/config/resource/IngressConfigTest.java
+++ b/jkube-kit/config/resource/src/test/java/org/eclipse/jkube/kit/config/resource/IngressConfigTest.java
@@ -14,7 +14,7 @@
 package org.eclipse.jkube.kit.config.resource;
 
 import com.fasterxml.jackson.databind.MapperFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
@@ -29,8 +29,9 @@ class IngressConfigTest {
   @Test
   void rawDeserialization() throws IOException {
     // Given
-    final ObjectMapper mapper = new ObjectMapper();
-    mapper.configure(MapperFeature.USE_ANNOTATIONS, false);
+    final JsonMapper mapper = JsonMapper.builder()
+        .configure(MapperFeature.USE_ANNOTATIONS, false)
+        .build();
     // When
     final IngressConfig result = mapper.readValue(
         IngressConfigTest.class.getResourceAsStream("/ingress-config.json"),


### PR DESCRIPTION
## Description

Fixes #3157 
Fixes #2527

1. Replaced `asList()` method with `asInstanceOf(...)`
2. Replaced `hasSize(1).element(0)` with `singleElement()`
3. Used `JsonMapper.builder().configure(..)` instead of deprecated `ObjectMapper.configure(..)`



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
