### PR TITLE
chore(deprecated assertion):  replace asList with asInstanceOf

### DIFF
--- a/jkube-kit/jkube-kit-helidon/src/test/java/org/eclipse/jkube/helidon/generator/HelidonGeneratorTest.java
+++ b/jkube-kit/jkube-kit-helidon/src/test/java/org/eclipse/jkube/helidon/generator/HelidonGeneratorTest.java
@@ -17,6 +17,7 @@ import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.generator.api.GeneratorContext;
 import org.eclipse.jkube.kit.common.Assembly;
 import org.eclipse.jkube.kit.common.AssemblyConfiguration;
+import org.eclipse.jkube.kit.common.AssemblyFileSet;
 import org.eclipse.jkube.kit.common.Dependency;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
@@ -193,7 +194,8 @@ class HelidonGeneratorTest {
     final List<ImageConfiguration> result = new HelidonGenerator(ctx).customize(new ArrayList<>(), true);
     // Then
     assertThat(result).singleElement()
-      .extracting("buildConfiguration.ports").asList()
+      .extracting("buildConfiguration.ports")
+      .asInstanceOf(InstanceOfAssertFactories.list(String.class))
       .contains("8778");
   }
 
@@ -218,7 +220,8 @@ class HelidonGeneratorTest {
     final List<ImageConfiguration> result = new HelidonGenerator(ctx).customize(new ArrayList<>(), true);
     // Then
     assertThat(result).singleElement()
-      .extracting("buildConfiguration.ports").asList()
+      .extracting("buildConfiguration.ports")
+      .asInstanceOf(InstanceOfAssertFactories.list(String.class))
       .contains("9779");
   }
 
@@ -256,20 +259,25 @@ class HelidonGeneratorTest {
         .hasFieldOrPropertyWithValue("targetDir", "/deployments")
         .hasFieldOrPropertyWithValue("excludeFinalOutputArtifact", true)
         .extracting(AssemblyConfiguration::getLayers)
-        .asList().hasSize(2)
+        .asInstanceOf(InstanceOfAssertFactories.list(Assembly.class))
+        .hasSize(2)
         .satisfies(layers -> assertThat(layers).first().asInstanceOf(InstanceOfAssertFactories.type(Assembly.class))
             .hasFieldOrPropertyWithValue("id", "libs")
             .extracting(Assembly::getFileSets)
-            .asList().singleElement()
+            .asInstanceOf(InstanceOfAssertFactories.list(AssemblyFileSet.class))
+            .singleElement()
             .hasFieldOrPropertyWithValue("outputDirectory", new File("."))
-            .extracting("includes").asList()
+            .extracting("includes")
+            .asInstanceOf(InstanceOfAssertFactories.list(String.class))
             .containsExactly("libs"))
         .satisfies(layers -> assertThat(layers).element(1).asInstanceOf(InstanceOfAssertFactories.type(Assembly.class))
             .hasFieldOrPropertyWithValue("id", "artifact")
             .extracting(Assembly::getFileSets)
-            .asList().singleElement()
+            .asInstanceOf(InstanceOfAssertFactories.list(AssemblyFileSet.class))
+            .singleElement()
             .hasFieldOrPropertyWithValue("outputDirectory", new File("."))
-            .extracting("includes").asList()
+            .extracting("includes")
+            .asInstanceOf(InstanceOfAssertFactories.list(String.class))
             .containsExactly("sample.jar"));
   }
 
@@ -293,9 +301,10 @@ class HelidonGeneratorTest {
         .extracting(BuildConfiguration::getAssembly)
         .hasFieldOrPropertyWithValue("targetDir", "/")
         .extracting(AssemblyConfiguration::getLayers)
-        .asList().singleElement().asInstanceOf(InstanceOfAssertFactories.type(Assembly.class))
+        .asInstanceOf(InstanceOfAssertFactories.list(Assembly.class))
+        .singleElement().asInstanceOf(InstanceOfAssertFactories.type(Assembly.class))
         .extracting(Assembly::getFileSets)
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(AssemblyFileSet.class))
         .hasSize(1)
         .flatExtracting("includes")
         .containsExactly("sample");


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Replace `asList` with `asInstanceOf`
Fixes #3159


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
