### PR TITLE
Issue-Fix-#2842 chore(test): fixed unit tests failing for gradle-plugin in Windows

### DIFF
--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesConfigViewTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesConfigViewTaskTest.java
@@ -48,6 +48,6 @@ class KubernetesConfigViewTaskTest {
     configViewTask.runTask();
     // Then
     verify(taskEnvironment.logger, times(1))
-        .lifecycle(matches("k8s: \n---\noffline: true\nbuildStrategy: \"s2i\""));
+        .lifecycle(matches(String.format("k8s: %n---\noffline: true\nbuildStrategy: \"s2i\"")));
   }
 }

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmPushTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmPushTaskTest.java
@@ -26,6 +26,7 @@ import org.mockito.MockedConstruction;
 import java.io.IOException;
 import java.nio.file.NoSuchFileException;
 
+import static org.apache.commons.io.FilenameUtils.separatorsToSystem;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockConstruction;
@@ -60,7 +61,7 @@ class KubernetesHelmPushTaskTest {
     // When & Then
     assertThatIllegalStateException()
         .isThrownBy(kubernetesHelmPushTask::runTask)
-        .withMessageContaining("META-INF/jkube/kubernetes")
+        .withMessageContaining(separatorsToSystem("META-INF/jkube/kubernetes"))
         .withCauseInstanceOf(NoSuchFileException.class);
   }
 

--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmTaskTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.MockedConstruction;
 
+import static org.apache.commons.io.FilenameUtils.separatorsToSystem;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mockConstruction;
@@ -60,7 +61,7 @@ class KubernetesHelmTaskTest {
     // When & Then
     assertThatIllegalStateException()
         .isThrownBy(kubernetesHelmTask::runTask)
-        .withMessageContaining("META-INF/jkube/kubernetes")
+        .withMessageContaining(separatorsToSystem("META-INF/jkube/kubernetes"))
         .withCauseInstanceOf(NoSuchFileException.class);
   }
 


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #2842 

For `KubernetesHelmPushTaskTest` & `KubernetesHelmTaskTest`:

The issue was occurring due to the use of linux file separator instead of the native file separator. The issue was fixed with the help of `separatorsToSystem()`.

For `KubernetesConfigViewTaskTest`:

The issue was related to the use of Line Feed in place in of native line separator. The issue fixed by modifying the test to use native line separator.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
