### PR TITLE
fix (jkube-kit/common) : Update `KubernetesHelper.exportKubernetesClientConfigToFile` to add opinionated Cluster Context

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -13,12 +13,10 @@
  */
 package org.eclipse.jkube.kit.common.util;
 
-
 import java.io.File;
 import java.io.IOException;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
@@ -859,6 +857,9 @@ public class KubernetesHelper {
         }
         if (StringUtils.isNotBlank(kubernetesClientConfig.getCaCertData())) {
             clusterBuilder.withCertificateAuthorityData(kubernetesClientConfig.getCaCertData());
+        }
+        if (kubernetesClientConfig.isTrustCerts()) {
+            clusterBuilder.withInsecureSkipTlsVerify(true);
         }
         return new NamedClusterBuilder().withName(Optional.ofNullable(kubernetesClientConfig.getCurrentContext())
             .map(NamedContext::getContext)

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesMockServerUtil.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesMockServerUtil.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Red Hat, Inc.
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at:
+ *
+ *     https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *   Red Hat, Inc. - initial API and implementation
+ */
+package org.eclipse.jkube.kit.common.util;
+
+import io.fabric8.kubernetes.api.model.NamedContext;
+import io.fabric8.kubernetes.api.model.NamedContextBuilder;
+import io.fabric8.kubernetes.client.Config;
+import org.eclipse.jkube.kit.common.JKubeException;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Optional;
+
+public class KubernetesMockServerUtil {
+  private KubernetesMockServerUtil() { }
+
+  public static NamedContext createOpinionatedKubernetesContextForMockKubernetesClientConfiguration(Config kubernetesClientConfig) {
+    try {
+      if (kubernetesClientConfig != null && kubernetesClientConfig.getCurrentContext() == null) {
+        URI uri = new URI(kubernetesClientConfig.getMasterUrl());
+        return new NamedContextBuilder()
+          .withName("jkube-context")
+          .withNewContext()
+          .withNamespace(kubernetesClientConfig.getNamespace())
+          .withCluster(String.format("%s:%d", uri.getHost(), uri.getPort()))
+          .withUser(Optional.ofNullable(kubernetesClientConfig.getUsername())
+            .orElse("jkube"))
+          .endContext()
+          .build();
+      }
+      return null;
+    } catch (URISyntaxException uriSyntaxException) {
+      throw new JKubeException("Invalid Kubernetes cluster url ", uriSyntaxException);
+    }
+  }
+}


### PR DESCRIPTION

## Description

Required by https://github.com/eclipse-jkube/jkube/pull/3142

+ When using KubernetesClient with Kubernetes Mock Server, `kubernetesClient.getConfiguration()` returns a Config object with no context set.
+ `kubernetesClient.getConfiguration()` does not provide any certificate data. When no certificate data is provided add `InsecureSkipTlsVerify` option in kubeconfig

Handle this case in KubernetesHelper to create an opinionated Context until this gets fixed in KubernetesMockServer



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
