### PR TITLE
fix: Fixed failing test on Windows

### DIFF
--- a/openshift-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenShiftResourceMojoTest.java
+++ b/openshift-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/OpenShiftResourceMojoTest.java
@@ -85,7 +85,7 @@ class OpenShiftResourceMojoTest {
     final File generatedArtifact = new File(resourceMojo.targetDir, "openshift.yml");
     assertThat(generatedArtifact)
       .exists()
-      .content().isEqualTo("---\napiVersion: v1\nkind: List\n");
+      .content().isEqualTo(String.format("---%napiVersion: v1%nkind: List%n"));
     verify(resourceMojo.projectHelper, times(1))
       .attachArtifact(resourceMojo.project, "yml", "openshift", generatedArtifact);
   }


### PR DESCRIPTION
OpenShiftResourceMojoTest is failing on Windows due to use of \n as line separator.

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #3180 
OpenShiftResourceMojoTest is failing on Windows due to use of \n as line separator #3180

Fix: Replaced \n with %n that would be platform independent
## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [ ] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
