### PR TITLE
fix: ImageEnricher#mergeEnvVariables causes error for empty env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Usage:
 * Fix #2110: Add new helm dependency update goal task (`k8s:helm-dependency-update` for maven and `k8sHelmDependencyUpdate` for gradle)
 * Fix #3122: JKube should also pass project directory in `buildpacks` build strategy
 * Fix #2467: Add support for specifying imagePullSecrets via resource configuration
+* Fix #3220: ImageEnricher#mergeEnvVariables causes error for empty env
 
 _**Note**_:
 - `defaultStorageClass` and `useStorageClassAnnotation` fields have been removed from VolumePermissionEnricher (`jkube-volume-permission`). Users are advised to use these fields from PersistentVolumeClaimStorageClassEnricher (`jkube-persistentvolumeclaim-storageclass`) instead.

--- a/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
+++ b/jkube-kit/enricher/generic/src/main/java/org/eclipse/jkube/enricher/generic/ImageEnricher.java
@@ -284,7 +284,7 @@ public class ImageEnricher extends BaseEnricher {
                 EnvVar newEnvVar =
                     new EnvVarBuilder()
                         .withName(resourceEnvEntry.getKey())
-                        .withValue(resourceEnvEntry.getValue())
+                        .withValue(Optional.ofNullable(resourceEnvEntry.getValue()).orElse(""))
                         .build();
 
                 EnvVar oldEnvVar = containerEnvVars.stream()

--- a/kubernetes-maven-plugin/it/src/it/env-metadata/expected/kubernetes.yml
+++ b/kubernetes-maven-plugin/it/src/it/env-metadata/expected/kubernetes.yml
@@ -72,6 +72,7 @@ items:
       spec:
         containers:
         - env:
+          - name: MY_ENV_empty
           - name: MY_ENV_key
             value: MY_ENV_value
           - name: KUBERNETES_NAMESPACE

--- a/kubernetes-maven-plugin/it/src/it/env-metadata/pom.xml
+++ b/kubernetes-maven-plugin/it/src/it/env-metadata/pom.xml
@@ -51,6 +51,7 @@
         <configuration>
           <resources>
             <env>
+              <MY_ENV_empty></MY_ENV_empty>
               <MY_ENV_key>MY_ENV_value</MY_ENV_key>
               <KUBERNETES_NAMESPACE>this_will_not_be_overridden</KUBERNETES_NAMESPACE>
             </env>


### PR DESCRIPTION
## Description
Handle env variable with null value, translating it as empty String to avoid error on compare operation

Fixes #3220 


## Type of change

 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
