### PR TITLE
fix (jkube-kit/common) : `KubernetesHelper.exportKubernetesClientConfigToFile` should not set certificate related fields in NamedCluster when `trustCerts=true`

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/KubernetesHelper.java
@@ -852,10 +852,10 @@ public class KubernetesHelper {
         if (StringUtils.isNotBlank(kubernetesClientConfig.getMasterUrl())) {
             clusterBuilder.withServer(kubernetesClientConfig.getMasterUrl());
         }
-        if (StringUtils.isNotBlank(kubernetesClientConfig.getCaCertFile())) {
+        if (StringUtils.isNotBlank(kubernetesClientConfig.getCaCertFile()) && !kubernetesClientConfig.isTrustCerts()) {
             clusterBuilder.withCertificateAuthority(kubernetesClientConfig.getCaCertFile());
         }
-        if (StringUtils.isNotBlank(kubernetesClientConfig.getCaCertData())) {
+        if (StringUtils.isNotBlank(kubernetesClientConfig.getCaCertData()) && !kubernetesClientConfig.isTrustCerts()) {
             clusterBuilder.withCertificateAuthorityData(kubernetesClientConfig.getCaCertData());
         }
         if (kubernetesClientConfig.isTrustCerts()) {


### PR DESCRIPTION

## Description

While adapting tests in HelmService for install goal #3142 , I'm facing problems with exported kubeconfig file in HelmServiceInstallIT . It is getting rejected by Kubernetes as invalid kubeconfig file.

```
java.lang.IllegalStateException: Kubernetes cluster unreachable: specifying a root certificates file with the insecure flag is not allowed
```

In KubernetesMockServer tests, we enable `trustCerts` option to skip certificate verification. However, [ClusterConfiguration `getConfig()`](https://github.com/eclipse-jkube/jkube/blob/ee6f352541400fbb9a784f67acc455251ee03de9/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/access/ClusterConfiguration.java#L69) method creates a KubernetesClient config object by merging opinionated default with user provided cluster attributes, this causes resulting config to contain additional fields from user's kubernetes environment.
```
---
clusters:
- cluster:
   certificate-authority: "/home/user/.minikube/ca.crt"
   insecure-skip-tls-verify: true
   server: "https://localhost:33413/"
```


To work around this error, we should not set `certificateAuthority` and `certificateAuthorityData` fields whenever `trustCerts` is enabled.



## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [X] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
