### PR TITLE
fix (jkube-kit-spring-boot) : Directly read `layers.idx` file to get layers information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Usage:
 * Fix #3161: JavaExecGenerator should honor %t setting and not unconditionally add `latest` tag
 * Fix #2467: Add support for specifying imagePullSecrets via resource configuration
 * Fix #3220: ImageEnricher#mergeEnvVariables causes error for empty env
+* Fix #3228: Springboot 3.3.1 layertools output format breaks LayeredJarGenerator
 
 _**Note**_:
 - `defaultStorageClass` and `useStorageClassAnnotation` fields have been removed from VolumePermissionEnricher (`jkube-volume-permission`). Users are advised to use these fields from PersistentVolumeClaimStorageClassEnricher (`jkube-persistentvolumeclaim-storageclass`) instead.


### PR DESCRIPTION
## Description

Fix #3228

Till now we were executing layertools list command to extract layer related information for Spring Boot Layered jar. This has started causing problems in Spring Boot 3.3.x where we're getting additional deprecation warning that's breaking behavior of SpringBootGenerator. Additionally, layertools command has become deprecated in Spring Boot 3.3.x

Instead of relying on layertools command, directly read layers.idx file present in layered jar to extract list of layers. `layers.idx` file format seems to be consistent across previous Spring Boot versions. You can see it's spec in [LayersIndex.java](https://github.com/spring-projects/spring-boot/blob/3648f5f494e6b5bb010bb7f881eb748cbc0f8cc5/spring-boot-project/spring-boot-tools/spring-boot-loader-tools/src/main/java/org/springframework/boot/loader/tools/LayersIndex.java#L35) : 

> Index describing the layer to which each entry in a jar belongs. Index files are simple text files that should be read from top to bottom. Each file defines the layers and their content. Layer names are written as quoted strings prefixed by a dash space  `"- "` and with a colon `":"` suffix. Layer content is either a file or directory name written as a quoted string prefixed by space dash space `"  - "`. A directory name ends with`/`, a file name does not. When a directory name is used it means that all files inside that directory are in the same layer.

> Index files are designed to be compatible with YAML and may be read into a list of `Map<String, List<String>>` instances.

Existing tests verify that the SpringBootLayeredJar works as expected even after making this change.

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [X] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [X] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [X] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [X] My code follows the style guidelines of this project
 - [X] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [X] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [X] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [X] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
