### PR TITLE
refactor: improve assertion statements for RegistryConfigTest

### DIFF
--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/RegistryConfigTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/RegistryConfigTest.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,7 +43,8 @@ class RegistryConfigTest {
         .hasFieldOrPropertyWithValue("registry", "the-registry")
         .hasFieldOrPropertyWithValue("skipExtendedAuth", true)
         .hasFieldOrPropertyWithValue("authConfig", null)
-        .extracting(RegistryConfig::getSettings).asList().hasSize(1).extracting("id", "username")
+        .extracting(RegistryConfig::getSettings).asInstanceOf(InstanceOfAssertFactories.list(RegistryConfig.class)).hasSize(1)
+        .extracting("id", "username")
         .containsExactly(tuple("server-1", "the-user"));
   }
 }

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/RegistryConfigTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/RegistryConfigTest.java
@@ -43,7 +43,8 @@ class RegistryConfigTest {
         .hasFieldOrPropertyWithValue("registry", "the-registry")
         .hasFieldOrPropertyWithValue("skipExtendedAuth", true)
         .hasFieldOrPropertyWithValue("authConfig", null)
-        .extracting(RegistryConfig::getSettings).asInstanceOf(InstanceOfAssertFactories.list(RegistryConfig.class)).hasSize(1)
+        .extracting(RegistryConfig::getSettings).asInstanceOf(InstanceOfAssertFactories.list(RegistryServerConfiguration.class))
+        .hasSize(1)
         .extracting("id", "username")
         .containsExactly(tuple("server-1", "the-user"));
   }


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes https://github.com/eclipse-jkube/jkube/issues/3238


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
