### PR TITLE
fix: Failing Test in `KubernetesHelperTest` on windows machine

### DIFF
--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
@@ -494,8 +494,8 @@ class KubernetesHelperTest {
                       .map(Object::toString)
                       .collect(Collectors.toList());
                   assertThat(actualUrls).hasSize(2)
-                      .contains("https://" + mockServer.getHostName() + ":" + mockServer.getPort() + "/",
-                          "localhost:" + mockServer.getPort());
+                      .contains(String.format("https://%s:%d/", mockServer.getHostName(), mockServer.getPort()),
+                          String.format("localhost:" + mockServer.getPort()));
                 }))
           .satisfies(c -> assertThat(c.getUsers())
             .singleElement(InstanceOfAssertFactories.type(NamedAuthInfo.class))

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
@@ -470,10 +470,6 @@ class KubernetesHelperTest {
     @Test
     @DisplayName("should work with KubernetesClient config provided by KubernetesMockServer")
     void exportKubernetesClientConfigToFile_worksWithKubernetesMockServer(@TempDir Path temporaryFolder) throws IOException {
-        String expectedHostName = mockServer.getHostName();
-        int expectedPort = mockServer.getPort();
-        String expectedClusterServerUrl = "https://" + expectedHostName + ":" + expectedPort + "/";
-        String expectedNameUrl = "localhost:" + expectedPort;
         // When
         final Path result = KubernetesHelper.exportKubernetesClientConfigToFile(mockClient.getConfiguration(), temporaryFolder.resolve("config"));
         // Then
@@ -498,7 +494,8 @@ class KubernetesHelperTest {
                       .map(Object::toString)
                       .collect(Collectors.toList());
                   assertThat(actualUrls).hasSize(2)
-                      .contains(expectedClusterServerUrl, expectedNameUrl);
+                      .contains("https://" + mockServer.getHostName() + ":" + mockServer.getPort() + "/",
+                          "localhost:" + mockServer.getPort());
                 }))
           .satisfies(c -> assertThat(c.getUsers())
             .singleElement(InstanceOfAssertFactories.type(NamedAuthInfo.class))

--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
@@ -495,7 +495,7 @@ class KubernetesHelperTest {
                       .collect(Collectors.toList());
                   assertThat(actualUrls).hasSize(2)
                       .contains(String.format("https://%s:%d/", mockServer.getHostName(), mockServer.getPort()),
-                          String.format("localhost:" + mockServer.getPort()));
+                          String.format("localhost:%d", mockServer.getPort()));
                 }))
           .satisfies(c -> assertThat(c.getUsers())
             .singleElement(InstanceOfAssertFactories.type(NamedAuthInfo.class))


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes https://github.com/eclipse-jkube/jkube/issues/3205


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
