### PR TITLE
Replace string.length with isEmpty in OpenShiftBuildServiceUtils

### DIFF
--- a/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceUtils.java
+++ b/jkube-kit/config/service/src/main/java/org/eclipse/jkube/kit/config/service/openshift/OpenShiftBuildServiceUtils.java
@@ -250,7 +250,7 @@ public class OpenShiftBuildServiceUtils {
   private static boolean checkForNocache(ImageConfiguration imageConfig) {
     String nocache = System.getProperty("docker.nocache");
     if (nocache != null) {
-      return nocache.length() == 0 || Boolean.parseBoolean(nocache);
+      return nocache.isEmpty() || Boolean.parseBoolean(nocache);
     } else {
       BuildConfiguration buildConfig = imageConfig.getBuildConfiguration();
       return buildConfig.nocache();


### PR DESCRIPTION
## Description
The code is cleaned up a little by replacing the nocache.length() == 0 with nocache.isEmpty in OpenShiftBuildServiceUtils

Fixes #3235

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

