### PR TITLE
WebServerEventCollector 'evts.size() > 0' can be replaced with '!evts.isEmpty()'

### DIFF
--- a/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/WebServerEventCollector.java
+++ b/jkube-kit/config/service/src/test/java/org/eclipse/jkube/kit/config/service/openshift/WebServerEventCollector.java
@@ -63,7 +63,7 @@ public class WebServerEventCollector {
         LinkedList<String> evts = new LinkedList<>(this.events);
         for (String exp : expectedEvents) {
             boolean found = false;
-            while (!found && evts.size() > 0) {
+            while (!found && !evts.isEmpty()) {
                 String ev = evts.pop();
                 found = exp.equals(ev);
             }


### PR DESCRIPTION
## Description
Fixes #3260 

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
