### PR TITLE
chore: replace deprecated asList() in DeploymentConfigHandlerTest with asInstanceOf()

### DIFF
--- a/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/DeploymentConfigHandlerTest.java
+++ b/jkube-kit/enricher/api/src/test/java/org/eclipse/jkube/kit/enricher/handler/DeploymentConfigHandlerTest.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
+import io.fabric8.kubernetes.api.model.Container;
 import org.eclipse.jkube.kit.config.image.ImageConfiguration;
 import org.eclipse.jkube.kit.config.image.build.BuildConfiguration;
 import org.eclipse.jkube.kit.config.resource.ControllerResourceConfig;
@@ -33,6 +34,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import org.assertj.core.api.InstanceOfAssertFactories;
 
 class DeploymentConfigHandlerTest {
 
@@ -67,7 +69,7 @@ class DeploymentConfigHandlerTest {
     // Then
     assertThat(result)
         .hasFieldOrPropertyWithValue("metadata.name", "controller")
-        .extracting("spec.template.spec.containers").asList().isEmpty();
+        .extracting("spec.template.spec.containers").asInstanceOf(InstanceOfAssertFactories.list(Container.class)).isEmpty();
   }
 
   @Test
@@ -83,7 +85,7 @@ class DeploymentConfigHandlerTest {
     // Then
     assertThat(result)
         .hasFieldOrPropertyWithValue("metadata.name", "controller")
-        .extracting("spec.template.spec.containers").asList().hasSize(2)
+        .extracting("spec.template.spec.containers").asInstanceOf(InstanceOfAssertFactories.list(Container.class)).hasSize(2)
         .extracting("image", "name")
         .containsExactly(new Tuple("busybox:latest", "g-a"), new Tuple("jkubeio/java:latest", "jkubeio-a"));
   }
@@ -96,7 +98,7 @@ class DeploymentConfigHandlerTest {
     // When
     final PodTemplateSpec result = deploymentConfigHandler.getPodTemplateSpec(controllerResourceConfig, images);
     // Then
-    assertThat(result).extracting("spec.containers").asList().isEmpty();
+    assertThat(result).extracting("spec.containers").asInstanceOf(InstanceOfAssertFactories.list(Container.class)).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Description

Fixes # 3266

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
