### PR TITLE
chore(JibServiceUtilTest): replace deprecated asList method, issue #3242

### DIFF
--- a/jkube-kit/build/service/jib/src/test/java/org/eclipse/jkube/kit/service/jib/JibServiceUtilTest.java
+++ b/jkube-kit/build/service/jib/src/test/java/org/eclipse/jkube/kit/service/jib/JibServiceUtilTest.java
@@ -15,11 +15,8 @@ package org.eclipse.jkube.kit.service.jib;
 
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
-import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
-import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
-import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
-import com.google.cloud.tools.jib.api.buildplan.Platform;
-import com.google.cloud.tools.jib.api.buildplan.Port;
+import com.google.cloud.tools.jib.api.buildplan.*;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.kit.build.api.assembly.BuildDirs;
 import org.eclipse.jkube.kit.common.Assembly;
 import org.eclipse.jkube.kit.common.AssemblyConfiguration;
@@ -317,17 +314,23 @@ class JibServiceUtilTest {
       assertThat(result).hasSize(3)
         .anySatisfy(fel -> assertThat(fel)
           .hasFieldOrPropertyWithValue("name", "layer-1")
-          .extracting(FileEntriesLayer::getEntries).asList().extracting("extractionPath.unixPath")
+          .extracting(FileEntriesLayer::getEntries)
+          .asInstanceOf(InstanceOfAssertFactories.list(FileEntry.class))
+          .extracting("extractionPath.unixPath")
           .containsExactly("/l1.1.txt", "/l1.2.txt")
         )
         .anySatisfy(fel -> assertThat(fel)
           .hasFieldOrPropertyWithValue("name", "")
-          .extracting(FileEntriesLayer::getEntries).asList().extracting("extractionPath.unixPath")
+          .extracting(FileEntriesLayer::getEntries)
+          .asInstanceOf(InstanceOfAssertFactories.list(FileEntry.class))
+          .extracting("extractionPath.unixPath")
           .containsExactly("/l2.1.txt", "/l2.2.txt")
         )
         .anySatisfy(fel -> assertThat(fel)
           .hasFieldOrPropertyWithValue("name", "jkube-generated-layer-final-artifact")
-          .extracting(FileEntriesLayer::getEntries).asList().extracting("extractionPath.unixPath")
+          .extracting(FileEntriesLayer::getEntries)
+          .asInstanceOf(InstanceOfAssertFactories.list(FileEntry.class))
+          .extracting("extractionPath.unixPath")
           .containsExactly("/deployments/edge.case")
         )
         .extracting(FileEntriesLayer::getName)

--- a/jkube-kit/build/service/jib/src/test/java/org/eclipse/jkube/kit/service/jib/JibServiceUtilTest.java
+++ b/jkube-kit/build/service/jib/src/test/java/org/eclipse/jkube/kit/service/jib/JibServiceUtilTest.java
@@ -15,7 +15,12 @@ package org.eclipse.jkube.kit.service.jib;
 
 import com.google.cloud.tools.jib.api.ImageReference;
 import com.google.cloud.tools.jib.api.JibContainerBuilder;
-import com.google.cloud.tools.jib.api.buildplan.*;
+import com.google.cloud.tools.jib.api.buildplan.AbsoluteUnixPath;
+import com.google.cloud.tools.jib.api.buildplan.FileEntriesLayer;
+import com.google.cloud.tools.jib.api.buildplan.FileEntry;
+import com.google.cloud.tools.jib.api.buildplan.ImageFormat;
+import com.google.cloud.tools.jib.api.buildplan.Platform;
+import com.google.cloud.tools.jib.api.buildplan.Port;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.kit.build.api.assembly.BuildDirs;
 import org.eclipse.jkube.kit.common.Assembly;


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #3242 
Replace deprecated asList method 

## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
