### PR TITLE
removed/ replaced Unecessery Function call longTage.toString()

### DIFF
--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java
@@ -146,7 +146,7 @@ class ImageNameTest {
       @DisplayName("illegal docker name, should throw exception")
       @ValueSource(strings = { "fo$z$", "Foo@3cc", "Foo$3", "Foo*3", "Fo^3", "Foo!3", "F)xcz(", "fo%asd", "FOO/bar",
           "repo:fo$z$", "repo:Foo@3cc", "repo:Foo$3", "repo:Foo*3", "repo:Fo^3", "repo:Foo!3",
-          "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..",
+          "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..","repo:" + longTag,
           "-busybox:test", "-test/busybox:test", "-index:5000/busybox:test",
           "repo:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
       })


### PR DESCRIPTION
This PR Fixses Issue in the class  [ImageNameTest](https://github.com/eclipse-jkube/jkube/blob/7561af9a2b36892b6c93863584d62d732e76938a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/ImageNameTest.java#L148) presents the issue: Unnecessary 'toString()' call.

Fix issue :#3261

Changes made in this fix:
Repalced below line code which making  Unnecessary 'toString()' call.
` "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..","repo:" + longTag.toString(),`

Updated Line of code:
`            "repo:%goodbye", "repo:#hashtagit", "repo:F)xcz(", "repo:-foo", "repo:..","repo:" + longTag,`