### PR TITLE
chore: replaces String concatenation arguments with StringBuilder.append() (2840)

### DIFF
--- a/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/ValidationUtil.java
+++ b/jkube-kit/common/src/main/java/org/eclipse/jkube/kit/common/util/ValidationUtil.java
@@ -42,7 +42,12 @@ public class ValidationUtil {
                     leafBean = "" + hasMetadata.getKind() + ": " + metadata;
                 }
             }
-            builder.append(violation.getPropertyPath() + " " + violation.getMessage() + " on bean: " + leafBean);
+            builder.append(violation.getPropertyPath())
+                    .append(" ")
+                    .append(violation.getMessage())
+                    .append(" on bean: ")
+                    .append(leafBean);
+
         }
         return builder.toString();
     }


### PR DESCRIPTION
## Description
Reduces code smell by replacing String concatenation in StringBuilder call with StringBuilder.append().
Fixes #2840


## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift