### PR TITLE
FIXED: HelmLintMojoTest.setUp The declared Exception exception is never thrown #3053 

### DIFF
--- a/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmLintMojoTest.java
+++ b/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmLintMojoTest.java
@@ -40,7 +40,7 @@ class HelmLintMojoTest {
 
 
   @BeforeEach
-  void setUp() throws Exception {
+  void setUp() {
     originalPrintStream = System.out;
     outputStream = new ByteArrayOutputStream();
     System.setOut(new PrintStream(outputStream));


### PR DESCRIPTION
### **Description**
 Fixed: #3053 
 
 The method [HelmLintMojoTest.setUp](https://github.com/eclipse-jkube/jkube/blob/b54dddcbbe8f1083e428f0f65835a1d5441b2df4/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmLintMojoTest.java#L43) was declaring an Exception that was never thrown.

The following line:
[jkube/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmLintMojoTest.java](https://github.com/eclipse-jkube/jkube/blob/b54dddcbbe8f1083e428f0f65835a1d5441b2df4/kubernetes-maven-plugin/plugin/src/test/java/org/eclipse/jkube/maven/plugin/mojo/build/HelmLintMojoTest.java#L43)

Line 43 in [b54dddc](https://github.com/eclipse-jkube/jkube/commit/b54dddcbbe8f1083e428f0f65835a1d5441b2df4)
`43  void setUp() throws Exception { `

- [x] it is now changed to

`43  void setUp() { `

### Checklist

- [x]  I have read the [contributing guidelines](https://www.eclipse.org/jkube/contributing)
- [x]  I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)

