### PR TITLE
fix: replace AssertJ's deprecated asList() DSL method in MicronautHea…

### DIFF
--- a/jkube-kit/jkube-kit-micronaut/src/test/java/org/eclipse/jkube/micronaut/enricher/MicronautHealthCheckEnricherTest.java
+++ b/jkube-kit/jkube-kit-micronaut/src/test/java/org/eclipse/jkube/micronaut/enricher/MicronautHealthCheckEnricherTest.java
@@ -86,7 +86,7 @@ class MicronautHealthCheckEnricherTest {
         .extracting(DeploymentSpec::getTemplate)
         .extracting(PodTemplateSpec::getSpec)
         .extracting(PodSpec::getContainers)
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
         .element(0, InstanceOfAssertFactories.type(Container.class))
         .hasFieldOrPropertyWithValue("livenessProbe", null)
         .hasFieldOrPropertyWithValue("readinessProbe", null);
@@ -106,7 +106,7 @@ class MicronautHealthCheckEnricherTest {
         .extracting(DeploymentSpec::getTemplate)
         .extracting(PodTemplateSpec::getSpec)
         .extracting(PodSpec::getContainers)
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
         .element(0, InstanceOfAssertFactories.type(Container.class))
         .hasFieldOrPropertyWithValue("livenessProbe", null)
         .hasFieldOrPropertyWithValue("readinessProbe", null);
@@ -125,7 +125,7 @@ class MicronautHealthCheckEnricherTest {
         .hasSize(2)
         .element(1, InstanceOfAssertFactories.type(Deployment.class))
         .extracting("spec.template.spec.containers")
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
         .element(0, InstanceOfAssertFactories.type(Container.class))
         .extracting(
             "livenessProbe.httpGet.path",
@@ -148,7 +148,7 @@ class MicronautHealthCheckEnricherTest {
         .hasSize(2)
         .element(1, InstanceOfAssertFactories.type(Deployment.class))
         .extracting("spec.template.spec.containers")
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
         .element(0, InstanceOfAssertFactories.type(Container.class))
         .extracting(
             "livenessProbe.httpGet.path",
@@ -175,7 +175,7 @@ class MicronautHealthCheckEnricherTest {
         .hasSize(2)
         .element(1, InstanceOfAssertFactories.type(Deployment.class))
         .extracting("spec.template.spec.containers")
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(Container.class))
         .element(0, InstanceOfAssertFactories.type(Container.class))
         .extracting(
             "livenessProbe.httpGet.path",


### PR DESCRIPTION
…lthCheckEnricherTest

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #3333 


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
