### PR TITLE
CleanupModeTest : refactor test to use @ParameterizedTest instead of loop

### DIFF
--- a/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/CleanupModeTest.java
+++ b/jkube-kit/config/image/src/test/java/org/eclipse/jkube/kit/config/image/build/CleanupModeTest.java
@@ -14,6 +14,11 @@
 package org.eclipse.jkube.kit.config.image.build;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -27,21 +32,21 @@ import static org.eclipse.jkube.kit.config.image.build.CleanupMode.TRY_TO_REMOVE
  */
 class CleanupModeTest {
 
-    @Test
-    void parse() {
+    @ParameterizedTest
+    @MethodSource("provideParseTestData")
+    void parse(String input, CleanupMode expected) {
+        assertThat(CleanupMode.parse(input)).isEqualTo(expected);
+    }
 
-        Object[] data = {
-            null, TRY_TO_REMOVE,
-            "try", TRY_TO_REMOVE,
-            "FaLsE", NONE,
-            "NONE", NONE,
-            "true", REMOVE,
-            "removE", REMOVE
-        };
-
-        for (int i = 0; i < data.length; i += 2) {
-            assertThat(CleanupMode.parse((String) data[i])).isEqualTo(data[i + 1]);
-        }
+    static Stream<Arguments> provideParseTestData() {
+        return Stream.of(
+            Arguments.of(null, CleanupMode.TRY_TO_REMOVE),
+            Arguments.of("try", CleanupMode.TRY_TO_REMOVE),
+            Arguments.of("FaLsE", CleanupMode.NONE),
+            Arguments.of("NONE", CleanupMode.NONE),
+            Arguments.of("true", CleanupMode.REMOVE),
+            Arguments.of("removE", CleanupMode.REMOVE)
+        );
     }
 
     @Test


### PR DESCRIPTION
## Description
- Added `@ParameterizedTest` to remove a `for` loop in `CleanupModeTest`.

Fixes #3345 

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
