### PR TITLE
fix: Casting 'serverUrls' to 'List<?>' is redundant

### DIFF
--- a/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
+++ b/jkube-kit/common/src/test/java/org/eclipse/jkube/kit/common/util/KubernetesHelperTest.java
@@ -490,7 +490,7 @@ class KubernetesHelperTest {
             .hasFieldOrPropertyWithValue("cluster.insecureSkipTlsVerify", true)
             .extracting("cluster.server", "name")
                 .satisfies(serverUrls -> {
-                  List<String> actualUrls = ((List<?>) serverUrls).stream()
+                  List<String> actualUrls = serverUrls.stream()
                       .map(Object::toString)
                       .collect(Collectors.toList());
                   assertThat(actualUrls).hasSize(2)


### PR DESCRIPTION
## Component
Jkube-kit

## Description

fix: Casting 'serverUrls' to 'List<?>' is redundant

Fixes #3337 


## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)
