### PR TITLE
fix(KubernetesBuildTasktest): Removed throws IOException from setUp()…

### DIFF
--- a/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTaskTest.java
+++ b/gradle-plugin/kubernetes/src/test/java/org/eclipse/jkube/gradle/plugin/task/KubernetesBuildTaskTest.java
@@ -56,7 +56,7 @@ class KubernetesBuildTaskTest {
   private boolean isBuildError;
 
   @BeforeEach
-  void setUp() throws IOException {
+  void setUp() {
     // Mock required for environments with no DOCKER available (don't remove)
     dockerAccessFactoryMockedConstruction = mockConstruction(DockerAccessFactory.class,
       (mock, ctx) -> when(mock.createDockerAccess(any())).thenReturn(mock(DockerAccess.class)));


### PR DESCRIPTION

Refs: #3390

## Description
In KubernetesBuildTasktest: Removed throws IOException from setUp() method declaration.

<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #3390 


## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [x] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [x] I tested my code in Kubernetes
 - [x] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
