### PR TITLE
Replaced deprecated-aslist-in-open-liberty-generator-test

### DIFF
--- a/jkube-kit/jkube-kit-openliberty/src/test/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGeneratorTest.java
+++ b/jkube-kit/jkube-kit-openliberty/src/test/java/org/eclipse/jkube/openliberty/generator/OpenLibertyGeneratorTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.generator.api.GeneratorContext;
 import org.eclipse.jkube.generator.javaexec.FatJarDetector;
 import org.eclipse.jkube.kit.common.AssemblyFileSet;
@@ -94,7 +95,7 @@ class OpenLibertyGeneratorTest {
     assertThat(result).singleElement()
         .extracting(ImageConfiguration::getBuildConfiguration)
         .extracting(BuildConfiguration::getPorts)
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(String.class))
         .containsExactly("9080", "8778", "9779");
   }
 


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
This pull request addresses issue #3403, where the deprecated `asList() `DSL method in the AssertJ framework is replaced with `asInstanceOf(InstanceOfAssertFactories.list(type.class)) ` in the OpenLibertyGeneratorTest class. This change is necessary to ensure compatibility with the latest versions of AssertJ, where the `asList() `method has been marked as deprecated.
Fixes #3403 


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
