### PR TITLE
Replace lambda with method reference in SpringBootGenerator (#3371)

### DIFF
--- a/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/generator/SpringBootGenerator.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/generator/SpringBootGenerator.java
@@ -84,7 +84,7 @@ public class SpringBootGenerator extends JavaExecGenerator {
 
     @Override
     protected Map<String, String> getEnv(boolean prePackagePhase) {
-        return nestedGenerator.getEnv(super::getEnv, prePackagePhase);
+        return nestedGenerator.getEnv(ppp -> super.getEnv(ppp), prePackagePhase);
     }
 
     @Override

--- a/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/generator/SpringBootGenerator.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/generator/SpringBootGenerator.java
@@ -84,6 +84,9 @@ public class SpringBootGenerator extends JavaExecGenerator {
 
     @Override
     protected Map<String, String> getEnv(boolean prePackagePhase) {
+        //TODO: Java8 compatibility, remove warning.
+        // Remove annotation once baseline is set to Java11+
+        //noinspection Convert2MethodRef
         return nestedGenerator.getEnv(ppp -> super.getEnv(ppp), prePackagePhase);
     }
 

--- a/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/generator/SpringBootGenerator.java
+++ b/jkube-kit/jkube-kit-spring-boot/src/main/java/org/eclipse/jkube/springboot/generator/SpringBootGenerator.java
@@ -84,7 +84,7 @@ public class SpringBootGenerator extends JavaExecGenerator {
 
     @Override
     protected Map<String, String> getEnv(boolean prePackagePhase) {
-        return nestedGenerator.getEnv(ppp -> super.getEnv(ppp), prePackagePhase);
+        return nestedGenerator.getEnv(super::getEnv, prePackagePhase);
     }
 
     @Override


### PR DESCRIPTION
Fixes #3371
- This pull request addresses issue #3371, which suggests replacing lambda expressions with method references where applicable in the SpringBootGenerator. Method references offer more concise syntax and can improve readability.

**Changes:**

- Refactored lambda expressions that can be simplified by method references.
- Updated occurrences where method references provide cleaner and more efficient code, ensuring no changes to the functionality of the SpringBootGenerator.

