### PR TITLE
fixes file locking issue in DependencyResourcesIT

### DIFF
--- a/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DependencyResourcesIT.java
+++ b/gradle-plugin/it/src/test/java/org/eclipse/jkube/gradle/plugin/tests/DependencyResourcesIT.java
@@ -32,7 +32,7 @@ class DependencyResourcesIT {
   void k8sResource_whenRun_generatesK8sManifestsIncludingDependencies() throws IOException, ParseException {
     // When
     final BuildResult result = gradleRunner.withITProject("dependency-resources")
-        .withArguments("clean", "jar", "k8sResource", "--stacktrace")
+        .withArguments("jar", "k8sResource", "--stacktrace")
         .build();
     // Then
     ResourceVerify.verifyResourceDescriptors(
@@ -49,12 +49,12 @@ class DependencyResourcesIT {
   void k8sResource_whenRunWithReplicas_generatesK8sManifestsIncludingDependencies() throws IOException, ParseException {
     // When
     final BuildResult result = gradleRunner.withITProject("dependency-resources")
-        .withArguments("-Pjkube.replicas=1337", "clean", "jar", "k8sResource", "--stacktrace")
+        .withArguments("-Pjkube.targetDir=build/classes/java/main/META-INF/jkube-replicas-override", "-Pjkube.replicas=1337", "jar", "k8sResource", "--stacktrace")
         .build();
     // Then
     ResourceVerify.verifyResourceDescriptors(
         gradleRunner.resolveFile("dependent", "build", "classes", "java", "main",
-            "META-INF", "jkube", "kubernetes.yml"),
+            "META-INF", "jkube-replicas-override", "kubernetes.yml"),
         gradleRunner.resolveFile("expected", "kubernetes-with-replica-override.yml"));
     assertThat(result).extracting(BuildResult::getOutput).asString()
         .contains("Using resource templates from")


### PR DESCRIPTION
## Description
Avoids conflict of file locks during clean phase by generating replica set in a different directory.
Fixes #3476 
Related to #3406 


## Type of change
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [ ] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [x] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
