### PR TITLE
Fix #3507: Replace Deprecated `asList()` Method in DefaultServiceEnricherAddMissingPartsTest

### DIFF
--- a/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
+++ b/jkube-kit/enricher/generic/src/test/java/org/eclipse/jkube/enricher/generic/DefaultServiceEnricherAddMissingPartsTest.java
@@ -16,6 +16,9 @@ package org.eclipse.jkube.enricher.generic;
 import java.util.Arrays;
 import java.util.Properties;
 
+
+import io.fabric8.kubernetes.api.model.ServicePort;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.eclipse.jkube.kit.common.JavaProject;
 import org.eclipse.jkube.kit.common.KitLogger;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
@@ -69,7 +72,7 @@ class DefaultServiceEnricherAddMissingPartsTest {
         .isInstanceOf(Service.class)
         .hasFieldOrPropertyWithValue("spec.type", null)
         .extracting("spec.ports")
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(ServicePort.class))
         .extracting("name", "port", "protocol")
         .containsOnly(new Tuple("http", 80, "TCP"));
   }
@@ -88,7 +91,7 @@ class DefaultServiceEnricherAddMissingPartsTest {
         .isInstanceOf(Service.class)
         .hasFieldOrPropertyWithValue("spec.type", null)
         .extracting("spec.ports")
-        .asList()
+        .asInstanceOf(InstanceOfAssertFactories.list(ServicePort.class))
         .extracting("name", "port", "protocol")
         .containsOnly(new Tuple("menandmice-dns", 1337, "TCP"));
   }


### PR DESCRIPTION
## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->

This pull request addresses **Issue #3507**, which involves replacing the deprecated `asList()` method in the `DefaultServiceEnricherAddMissingPartsTest` class with `asInstanceOf(InstanceOfAssertFactories.list(type.class))`. This update is necessary to ensure compatibility with the latest AssertJ library and to maintain code quality.
Fixes #3507 


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [ ] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
