### PR TITLE
SmallRyeHealthCheckEnricherTest seems to be using mock refactored wit…

### DIFF
--- a/jkube-kit/jkube-kit-smallrye/src/test/java/org/eclipse/jkube/smallrye/enricher/SmallRyeHealthCheckEnricherTest.java
+++ b/jkube-kit/jkube-kit-smallrye/src/test/java/org/eclipse/jkube/smallrye/enricher/SmallRyeHealthCheckEnricherTest.java
@@ -27,9 +27,9 @@ import org.eclipse.jkube.kit.enricher.api.JKubeEnricherContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import java.io.ByteArrayOutputStream;
+
 import java.io.File;
-import java.io.PrintStream;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -42,14 +42,13 @@ class SmallRyeHealthCheckEnricherTest {
   private JavaProject javaProject;
   private Properties properties;
   private KubernetesListBuilder klb;
-  private ByteArrayOutputStream out;
+
 
   @BeforeEach
   void setup() {
     properties = new Properties();
-    ProcessorConfig processorConfig = new ProcessorConfig();
     klb = new KubernetesListBuilder();
-    out = new ByteArrayOutputStream();
+
     klb.addToItems(new DeploymentBuilder()
         .editOrNewSpec()
         .editOrNewTemplate()
@@ -71,7 +70,7 @@ class SmallRyeHealthCheckEnricherTest {
             .dependenciesWithTransitive(new ArrayList<>())
             .build();
     context = JKubeEnricherContext.builder()
-            .log(new KitLogger.PrintStreamLogger(new PrintStream(out)))
+            .log(new KitLogger.SilentLogger()) 
             .project(javaProject)
             .processorConfig(new ProcessorConfig())
             .build();


### PR DESCRIPTION
…h real object using lombok builders

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #3522


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [ ] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [ ] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
