### PR TITLE
Removed unused import from KubernetesHelmLintTask.java

### DIFF
--- a/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmLintTask.java
+++ b/gradle-plugin/kubernetes/src/main/java/org/eclipse/jkube/gradle/plugin/task/KubernetesHelmLintTask.java
@@ -14,7 +14,6 @@
 package org.eclipse.jkube.gradle.plugin.task;
 
 import org.eclipse.jkube.gradle.plugin.KubernetesExtension;
-import org.eclipse.jkube.kit.resource.helm.HelmConfig;
 
 import javax.inject.Inject;
 


### PR DESCRIPTION
Fixes #3514

This pull request (#3514) removes the unused import 'org.eclipse.jkube.kit.resource.helm.HelmConfig' from the `KubernetesHelmLintTask.java` file.
