### PR TITLE
Issue #3613: Fix/unnecessary semicolon 

### DIFF
--- a/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/HealthCheckMode.java
+++ b/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/HealthCheckMode.java
@@ -24,6 +24,6 @@ public enum HealthCheckMode {
     /**
      * A command based health check.
      */
-    cmd;
+    cmd
 
 }


### PR DESCRIPTION
## Description

Fixes #3613


The class [HealthCheckMode](https://github.com/eclipse-jkube/jkube/blob/5da6068d7756784aef9569568ee80f98da97e296/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/HealthCheckMode.java#L27) presents the issue: Unnecessary semicolon `;`.

The following line:

[jkube/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/HealthCheckMode.java](https://github.com/eclipse-jkube/jkube/blob/5da6068d7756784aef9569568ee80f98da97e296/jkube-kit/config/image/src/main/java/org/eclipse/jkube/kit/config/image/build/HealthCheckMode.java#L27)

Line 27 in [5da6068](https://github.com/eclipse-jkube/jkube/commit/5da6068d7756784aef9569568ee80f98da97e296):

```java
cmd;
```
has been changed to:
```java
cmd
```


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report

