### PR TITLE
fix: remove Unnecessary call to 'toString()' in VertxHealthCheckEnricher.java (#3611)

### DIFF
--- a/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricher.java
+++ b/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricher.java
@@ -278,7 +278,7 @@ public class VertxHealthCheckEnricher extends AbstractHealthCheckEnricher {
             } else {
                 throw new IllegalArgumentException(String.format(
                     ERROR_MESSAGE,
-                    config.getKey(), input.getClass(), input.toString()));
+                    config.getKey(), input.getClass(), input));
             }
 
         });


### PR DESCRIPTION

## Description
<!--
Thank you for your pull request (PR)!

Please provide a description of what your PR does providing a link (if applicable) to the issue it fixes.
-->
Fixes #3611 

Removed Unnecessary call to 'toString()' in [VertxHealthCheckEnricher.java](https://github.com/eclipse-jkube/jkube/blob/a0a3369d3e82a2ee56034b9ecfec70e8c957b289/jkube-kit/jkube-kit-vertx/src/main/java/org/eclipse/jkube/vertx/enricher/VertxHealthCheckEnricher.java#L281)

Line 281:
```
config.getKey(), input.getClass(), input.toString()));
```
has been changed to:
```
config.getKey(), input.getClass(), input));
```


## Type of change
<!---
What types of changes does your code introduce? Put an `x` in all the boxes that apply
-->
 - [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [x] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code

<!--
Integration tests (https://github.com/eclipse-jkube/jkube-integration-tests)
Please check integration tests and provide/improve tests if necessary.

Open your PR in Draft mode and verify all of the applicable Checklist items before marking your issue as ready
-->
