### PR TITLE
docs: clarify oc:build defaults to cluster S2I #1528

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Usage:
 ```
 
 ### 1.21-SNAPSHOT
+* Fix #1528: Document that `oc:build` defaults to cluster S2I, not a local Docker daemon
 
 ### 1.20.0 (2026-07-21)
 * Fix #3903: Log pack CLI stderr output via kitLogger.error on buildpacks build failure

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_build_configuration_option_entries.adoc
@@ -1,6 +1,14 @@
 | *buildStrategy*
 a| Defines what build strategy to choose while building container image.
+
+ifeval::["{goal-prefix}" == "k8s"]
 Possible values are `docker`, `buildpacks` and `jib` out of which `docker` is default.
+Docker builds run against the local Docker daemon (`DOCKER_HOST` / `dockerHost`).
+endif::[]
+ifeval::["{task-prefix}" == "k8s"]
+Possible values are `docker`, `buildpacks` and `jib` out of which `docker` is default.
+Docker builds run against the local Docker daemon (`DOCKER_HOST` / `dockerHost`).
+endif::[]
 
 ifeval::["{goal-prefix}" == "oc"]
 include::_openshift_s2i_buildstrategy_entry.adoc[]

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_openshift-build.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_openshift-build.adoc
@@ -1,5 +1,8 @@
 [[build-openshift]]
 
+Unlike Kubernetes builds (<<build-kubernetes>>), which default to a **local** Docker daemon, OpenShift builds run **in the OpenShift cluster**.
+The default strategy is S2I. Setting `buildStrategy` to `docker` still performs an OpenShift Docker build on the cluster, not on your machine.
+
 For the `openshift` mode, OpenShift specific
 https://docs.openshift.com/enterprise/latest/architecture/core_concepts/builds_and_image_streams.html[builds] will be performed.
 These are so called

--- a/jkube-kit/doc/src/main/asciidoc/inc/build/_openshift_s2i_buildstrategy_entry.adoc
+++ b/jkube-kit/doc/src/main/asciidoc/inc/build/_openshift_s2i_buildstrategy_entry.adoc
@@ -1,7 +1,7 @@
-If the build is performed in an OpenShift cluster an additional `s2i` option is available
-and selected by default.
+Default is `s2i`. The image is built **in the OpenShift cluster**, not on a local Docker daemon.
 
 Available strategies for OpenShift are:
 
-* `s2i` for a https://docs.openshift.com/enterprise/latest/architecture/core_concepts/builds_and_image_streams.html#source-build[Source-to-Image build] with a binary source
-* `docker` for a https://docs.openshift.com/enterprise/latest/architecture/core_concepts/builds_and_image_streams.html#docker-build[Docker build] with a binary source
+* `s2i` for a https://docs.openshift.com/enterprise/latest/architecture/core_concepts/builds_and_image_streams.html#source-build[Source-to-Image build] with a binary source (default)
+* `docker` for a https://docs.openshift.com/enterprise/latest/architecture/core_concepts/builds_and_image_streams.html#docker-build[Docker build] with a binary source **on the OpenShift cluster** (not a local daemon)
+

--- a/openshift-maven-plugin/README.md
+++ b/openshift-maven-plugin/README.md
@@ -24,7 +24,7 @@ To enable OpenShift maven plugin on your project just add this to the plugins se
 | Goal                                                                                          | Description                                                                                    |
 |-----------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------|
 | [`oc:resource`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:resource)     | Create Kubernetes resource descriptors                                                         |
-| [`oc:build`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:build)           | Build Docker images                                                                            |
+| [`oc:build`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:build)           | Build images on the OpenShift cluster (S2I by default)                                         |
 | [`oc:push`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:push)             | Push Docker images to a registry                                                               |
 | [`oc:deploy`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:deploy)         | Deploy Kubernetes resource objects to a cluster                                                |
 | [`oc:helm`](https://www.eclipse.dev/jkube/docs/openshift-maven-plugin#jkube:helm)             | Generate Helm charts for your application                                                      |


### PR DESCRIPTION
## Description
The OpenShift `oc:build` docs still listed `docker` as the default `buildStrategy`, then mentioned S2I later. Docker is only the Kubernetes default. `oc:build` defaults to S2I, and the docker strategy still runs on the cluster, not on a local daemon.

Fixes #1528

## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] Feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to change
 - [x] Chore (non-breaking change which doesn't affect codebase;
   test, version modification, documentation, etc.)

## Checklist
 - [x] I have read the [contributing guidelines](https://www.eclipse.dev/jkube/contributing)
 - [ ] I signed-off my commit with a user that has signed the [Eclipse Contributor Agreement](https://www.eclipse.org/legal/ECA.php)
 - [x] My code follows the style guidelines of this project
 - [x] I Keep It Small and Simple: The smaller the PR is, the easier it is to review and have it merged
 - [x] I use [conventional commits](https://www.conventionalcommits.org/) in my commit messages
 - [x] I have performed a self-review of my code
 - [x] I Added [CHANGELOG](../CHANGELOG.md) entry
 - [x] I have updated the [documentation](../kubernetes-maven-plugin/doc) accordingly
 - [ ] No new bugs, code smells, etc. in [SonarCloud](https://sonarcloud.io/dashboard?id=jkubeio_jkube) report
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes
 - [ ] I tested my code in Kubernetes
 - [ ] I tested my code in OpenShift
